### PR TITLE
Fix serialisation

### DIFF
--- a/src/POData/Providers/Metadata/ResourceType.php
+++ b/src/POData/Providers/Metadata/ResourceType.php
@@ -939,4 +939,21 @@ class ResourceType
 
         return $reflect->getValue($entity);
     }
+
+    public function __sleep()
+    {
+        if (null == $this->_type || $this->_type instanceof \POData\Providers\Metadata\Type\IType) {
+            return array_keys(get_object_vars($this));
+        }
+        $this->_type = $this->_type->getName();
+        $result = array_keys(get_object_vars($this));
+        return $result;
+    }
+
+    public function __wakeup()
+    {
+        if (is_string($this->_type)) {
+            $this->_type = new \ReflectionClass($this->_type);
+        }
+    }
 }

--- a/src/POData/UriProcessor/UriProcessor.php
+++ b/src/POData/UriProcessor/UriProcessor.php
@@ -346,14 +346,16 @@ class UriProcessor
 
             $segment->setResult($entityInstance);
         } else {
+            $skip = (null == $this->request->getInternalSkipTokenInfo()) ? 0 :
+                $this->request->getInternalSkipTokenInfo()->getSkipTokenInfo()->getOrderByKeysInToken()[0][0];
             $queryResult = $this->providers->getResourceSet(
                 $this->request->queryType,
                 $segment->getTargetResourceSetWrapper(),
                 $this->request->getFilterInfo(),
                 $this->request->getInternalOrderByInfo(),
                 $this->request->getTopCount(),
-                $this->request->getSkipCount(),
-                $this->request->getInternalSkipTokenInfo()
+                $skip,
+                null
             );
             $segment->setResult($queryResult);
         }

--- a/tests/UnitTests/POData/Providers/ProvidersWrapperTest.php
+++ b/tests/UnitTests/POData/Providers/ProvidersWrapperTest.php
@@ -251,6 +251,8 @@ class ProvidersWrapperTest extends PhockitoUnitTestCase
         Phockito::when($this->mockResourceType->getName())
             ->return($fakeName);
 
+        Phockito::when($this->mockResourceType->__sleep())->return([]);
+
         $wrapper = $this->getMockedWrapper();
 
         try {
@@ -271,6 +273,8 @@ class ProvidersWrapperTest extends PhockitoUnitTestCase
         Phockito::when($this->mockResourceType->getName())
             ->return($fakeName);
 
+        Phockito::when($this->mockResourceType->__sleep())->return([]);
+
         $wrapper = $this->getMockedWrapper();
 
         $actual = $wrapper->getDerivedTypes($this->mockResourceType);
@@ -283,6 +287,8 @@ class ProvidersWrapperTest extends PhockitoUnitTestCase
             ->return(true);
 
         $wrapper = $this->getMockedWrapper();
+
+        Phockito::when($this->mockResourceType->__sleep())->return([]);
 
         $this->assertTrue($wrapper->hasDerivedTypes($this->mockResourceType));
     }
@@ -332,6 +338,8 @@ class ProvidersWrapperTest extends PhockitoUnitTestCase
 
         Phockito::when($this->mockResourceAssociationSetEnd->getResourceType())
             ->return($this->mockResourceType2);
+
+        Phockito::when($this->mockResourceType->__sleep())->return([]);
 
         $wrapper = $this->getMockedWrapper();
 
@@ -385,6 +393,8 @@ class ProvidersWrapperTest extends PhockitoUnitTestCase
 
         Phockito::when($this->mockResourceAssociationSetEnd->getResourceType())
             ->return($this->mockResourceType2);
+
+        Phockito::when($this->mockResourceType->__sleep())->return([]);
 
         $wrapper = $this->getMockedWrapper();
 

--- a/tests/UnitTests/POData/UriProcessor/UriProcessorTest.php
+++ b/tests/UnitTests/POData/UriProcessor/UriProcessorTest.php
@@ -2205,6 +2205,7 @@ class UriProcessorTest extends PhockitoUnitTestCase
                 null,
                 null,
                 null,
+                0,
                 null
             )
         )->return($fakeQueryResult);
@@ -2273,6 +2274,7 @@ class UriProcessorTest extends PhockitoUnitTestCase
                 null,
                 null,
                 null,
+                0,
                 null
             )
         )->return($fakeQueryResult);
@@ -2311,6 +2313,7 @@ class UriProcessorTest extends PhockitoUnitTestCase
                 null,
                 null,
                 null,
+                0,
                 null
             )
         )->return($fakeQueryResult);
@@ -2399,6 +2402,7 @@ class UriProcessorTest extends PhockitoUnitTestCase
                 null,
                 null,
                 null,
+                0,
                 null
             )
         )->return($fakeQueryResult);
@@ -2442,6 +2446,7 @@ class UriProcessorTest extends PhockitoUnitTestCase
                 null,
                 null,
                 null,
+                0,
                 null
             )
         )->return($fakeQueryResult);
@@ -2485,6 +2490,7 @@ class UriProcessorTest extends PhockitoUnitTestCase
                 null,
                 null,
                 null,
+                0,
                 null
             )
         )->return($fakeQueryResult);


### PR DESCRIPTION
Add __sleep and __wakeup methods to ResourceType to stop round-trip serialisation losing plot.
Fix skipToken handling to actually work.