### PR TITLE
Fix one (1) ACME-brand Genuine Schroedinbug

### DIFF
--- a/src/POData/Common/Messages/common.php
+++ b/src/POData/Common/Messages/common.php
@@ -42,7 +42,7 @@ trait common
      */
     public static function commonNotValidPrimitiveEDMType($argumentName, $functionName)
     {
-        return "The argument '$argumentName' to $functionName is not a valid EdmPrimitiveType Enum value";
+        return "The argument '$argumentName' to $functionName is not a valid EdmPrimitiveType Enum value.";
     }
 
     /**

--- a/src/POData/Providers/Metadata/ResourceType.php
+++ b/src/POData/Providers/Metadata/ResourceType.php
@@ -2,6 +2,7 @@
 
 namespace POData\Providers\Metadata;
 
+use InvalidArgumentException;
 use POData\Providers\Metadata\Type\Binary;
 use POData\Providers\Metadata\Type\Boolean;
 use POData\Providers\Metadata\Type\Byte;

--- a/src/POData/Providers/Metadata/SimpleMetadataProvider.php
+++ b/src/POData/Providers/Metadata/SimpleMetadataProvider.php
@@ -483,12 +483,13 @@ class SimpleMetadataProvider implements IMetadataProvider
     private function checkInstanceProperty($name, ResourceType $resourceType)
     {
         $instance = $resourceType->getInstanceType();
-        assert($instance instanceof \ReflectionClass, get_class($instance));
         $hasMagicGetter = $instance->hasMethod('__get');
 
         if (!$hasMagicGetter) {
             try {
-                $instance->getProperty($name);
+                if ($instance instanceof \ReflectionClass) {
+                    $instance->getProperty($name);
+                }
             } catch (\ReflectionException $exception) {
                 throw new InvalidOperationException(
                     'Can\'t add a property which does not exist on the instance type.'

--- a/src/POData/Providers/Metadata/SimpleMetadataProvider.php
+++ b/src/POData/Providers/Metadata/SimpleMetadataProvider.php
@@ -282,7 +282,7 @@ class SimpleMetadataProvider implements IMetadataProvider
      * @param ResourceType $resourceType resource type to which key property
      *                                   is to be added
      * @param string       $name         name of the property
-     * @param string       $typeCode     type of the etag property
+     * @param TypeCode     $typeCode     type of the etag property
      */
     public function addETagProperty($resourceType, $name, $typeCode)
     {

--- a/src/POData/Providers/Metadata/SimpleMetadataProvider.php
+++ b/src/POData/Providers/Metadata/SimpleMetadataProvider.php
@@ -3,6 +3,8 @@
 namespace POData\Providers\Metadata;
 
 use POData\Common\InvalidOperationException;
+use POData\Providers\Metadata\Type\TypeCode;
+use ReflectionClass;
 
 /**
  * Class SimpleMetadataProvider.
@@ -374,7 +376,9 @@ class SimpleMetadataProvider implements IMetadataProvider
         $primitiveResourceType = ResourceType::getPrimitiveResourceType($typeCode);
 
         if ($isETagProperty && $isBag) {
-            throw new InvalidOperationException('Only primitve property can be etag property, bag property cannot be etag property');
+            throw new InvalidOperationException(
+                'Only primitve property can be etag property, bag property cannot be etag property.'
+            );
         }
 
         $kind = $isKey ? ResourcePropertyKind::PRIMITIVE | ResourcePropertyKind::KEY : ResourcePropertyKind::PRIMITIVE;
@@ -479,8 +483,10 @@ class SimpleMetadataProvider implements IMetadataProvider
     private function checkInstanceProperty($name, ResourceType $resourceType)
     {
         $instance = $resourceType->getInstanceType();
+        assert($instance instanceof \ReflectionClass, get_class($instance));
+        $hasMagicGetter = $instance->hasMethod('__get');
 
-        if (!method_exists($instance, '__get')) {
+        if (!$hasMagicGetter) {
             try {
                 $instance->getProperty($name);
             } catch (\ReflectionException $exception) {

--- a/src/POData/Providers/Metadata/SimpleMetadataProvider.php
+++ b/src/POData/Providers/Metadata/SimpleMetadataProvider.php
@@ -3,6 +3,7 @@
 namespace POData\Providers\Metadata;
 
 use POData\Common\InvalidOperationException;
+use POData\Providers\Metadata\Type\IType;
 use POData\Providers\Metadata\Type\TypeCode;
 use ReflectionClass;
 
@@ -483,7 +484,7 @@ class SimpleMetadataProvider implements IMetadataProvider
     private function checkInstanceProperty($name, ResourceType $resourceType)
     {
         $instance = $resourceType->getInstanceType();
-        $hasMagicGetter = $instance->hasMethod('__get');
+        $hasMagicGetter = $instance instanceof IType || $instance->hasMethod('__get');
 
         if (!$hasMagicGetter) {
             try {

--- a/tests/UnitTests/POData/Providers/Metadata/ResourceClassesTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/ResourceClassesTest.php
@@ -43,7 +43,7 @@ class ResourceClassesTest extends \PHPUnit_Framework_TestCase
             ResourceType::getPrimitiveResourceType(TypeCode::VOID);
             $this->fail('An expected InvalidArgumentException for \'EdmPrimitiveType\' has not been raised');
         } catch (\InvalidArgumentException $exception) {
-            $this->assertStringEndsWith('is not a valid EdmPrimitiveType Enum value', $exception->getMessage());
+            $this->assertStringEndsWith('is not a valid EdmPrimitiveType Enum value.', $exception->getMessage());
         }
 
         $int16ResType = new ResourceType(new Int16(), ResourceTypeKind::PRIMITIVE, 'Int16', 'Edm');


### PR DESCRIPTION
Even though a given class may have a magic getter, it's arriving at
checkInstanceProperty encapsulated in a ReflectionClass object.  Original
magic __get method is then encapsulated via $foo->hasMethod('__get') call.

While broken, as explained above, this b0rked code merrily worked until
last night, when someone tripped over it and noticed it should never have.
As befits schroedinbug behaviour, it then promptly blew up for everyone,
worldwide.

I've tried to fix problem in two ways:
1 - Drop the erroneous method_exists check in favour of
$foo->hasMethod('__get');
2 - Assert what is returned by getInstancetype is, actually, an instance of
Reflection class.