### PR TITLE
Strip out html-expansion debris from Illuminate-request query parameters

### DIFF
--- a/src/POData/OperationContext/ServiceHost.php
+++ b/src/POData/OperationContext/ServiceHost.php
@@ -268,12 +268,14 @@ class ServiceHost
     }
 
     /**
-     * This method verfies the client provided url query parameters and check whether
-     * any of the odata query option specified more than once or check any of the
-     * non-odata query parameter start will $ symbol or check any of the odata query
-     * option specified with out value. If any of the above check fails throws
-     * ODataException, else set _queryOptions member variable.
+     * This method verifies the client provided url query parameters.
      *
+     * A query parameter is valid if and only if all the following conditions hold:
+     * 1. It does not duplicate another parameter
+     * 2. It has a supplied value.
+     * 3. If a non-OData query parameter, its name does not start with $.
+     * A valid parameter is then stored in _queryOptions, while an invalid parameter
+     * trips an ODataException
      *
      * @throws ODataException
      */
@@ -288,45 +290,35 @@ class ServiceHost
             $optionValue = current($queryOption);
             if (empty($optionName)) {
                 if (!empty($optionValue)) {
-                    if ($optionValue[0] == '$') {
+                    if ('$' == $optionValue[0]) {
                         if ($this->_isODataQueryOption($optionValue)) {
                             throw ODataException::createBadRequestError(
-                                Messages::hostODataQueryOptionFoundWithoutValue(
-                                    $optionValue
-                                )
+                                Messages::hostODataQueryOptionFoundWithoutValue($optionValue)
                             );
                         } else {
                             throw ODataException::createBadRequestError(
-                                Messages::hostNonODataOptionBeginsWithSystemCharacter(
-                                    $optionValue
-                                )
+                                Messages::hostNonODataOptionBeginsWithSystemCharacter($optionValue)
                             );
                         }
                     }
                 }
             } else {
-                if ($optionName[0] == '$') {
+                if ('$' == $optionName[0]) {
                     if (!$this->_isODataQueryOption($optionName)) {
                         throw ODataException::createBadRequestError(
-                            Messages::hostNonODataOptionBeginsWithSystemCharacter(
-                                $optionName
-                            )
+                            Messages::hostNonODataOptionBeginsWithSystemCharacter($optionName)
                         );
                     }
 
-                    if (array_search($optionName, $namesFound) !== false) {
+                    if (false !== array_search($optionName, $namesFound)) {
                         throw ODataException::createBadRequestError(
-                            Messages::hostODataQueryOptionCannotBeSpecifiedMoreThanOnce(
-                                $optionName
-                            )
+                            Messages::hostODataQueryOptionCannotBeSpecifiedMoreThanOnce($optionName)
                         );
                     }
 
-                    if (empty($optionValue) && $optionValue !== '0') {
+                    if (empty($optionValue) && '0' !== $optionValue) {
                         throw ODataException::createBadRequestError(
-                            Messages::hostODataQueryOptionFoundWithoutValue(
-                                $optionName
-                            )
+                            Messages::hostODataQueryOptionFoundWithoutValue($optionName)
                         );
                     }
 

--- a/src/POData/OperationContext/Web/Illuminate/IncomingIlluminateRequest.php
+++ b/src/POData/OperationContext/Web/Illuminate/IncomingIlluminateRequest.php
@@ -110,12 +110,13 @@ class IncomingIlluminateRequest implements IHTTPRequest
         $this->queryOptionsCount = [];
 
         foreach ($this->request->all() as $key => $value) {
-            $this->queryOptions[] = [$key => $value];
+            $keyBitz = explode(';', $key);
+            $newKey = $keyBitz[count($keyBitz) - 1];
+            $this->queryOptions[] = [$newKey => $value];
             if (!array_key_exists($key, $this->queryOptionsCount)) {
-                $this->queryOptionsCount[$key] = 1;
-            } else {
-                $this->queryOptionsCount[$key]++;
+                $this->queryOptionsCount[$newKey] = 0;
             }
+            $this->queryOptionsCount[$newKey]++;
         }
 
         return $this->queryOptions;

--- a/tests/UnitTests/POData/OperationContext/Web/IncomingIlluminateRequestTest.php
+++ b/tests/UnitTests/POData/OperationContext/Web/IncomingIlluminateRequestTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace UnitTests\POData\OperationContext\Web;
+
+use Illuminate\Http\Request;
+use POData\OperationContext\Web\Illuminate\IncomingIlluminateRequest;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use UnitTests\POData\TestCase;
+use Mockery as m;
+
+class IncomingIlluminateRequestTest extends TestCase
+{
+    public function testHandlingHtmlExpansionDebrisInParmNames()
+    {
+        $rawParm = [
+            '$orderBy' => 'CustomerTitle desc,id desc',
+            'amp;$top' => '1',
+            'amp;$skipToken' => "'University+of+Loamshire', 1, 1"
+        ];
+
+        $expectedParm = [
+            [ '$orderBy' => 'CustomerTitle desc,id desc'],
+            [ '$top' => '1'],
+            [ '$skipToken' => "'University+of+Loamshire', 1, 1"]
+        ];
+
+        $request = new Request($rawParm, $rawParm);
+        $request->setMethod('GET');
+
+        $foo = new IncomingIlluminateRequest($request);
+
+        $actualParm = $foo->getQueryParameters();
+        $this->assertEquals($expectedParm, $actualParm);
+    }
+
+    public function testFalseRequestHeaderReturnsNull()
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('header')->withAnyArgs()->andReturn(false);
+        $request->shouldReceive('getMethod')->andReturn('GET');
+
+        $foo = new IncomingIlluminateRequest($request);
+        $this->assertNull($foo->getRequestHeader('header'));
+    }
+
+    public function testEmptyRequestHeaderReturnsNull()
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('header')->withAnyArgs()->andReturn("");
+        $request->shouldReceive('getMethod')->andReturn('GET');
+
+        $foo = new IncomingIlluminateRequest($request);
+        $this->assertNull($foo->getRequestHeader('header'));
+    }
+
+    public function testNullRequestHeaderReturnsNull()
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('header')->withAnyArgs()->andReturn(null);
+        $request->shouldReceive('getMethod')->andReturn('GET');
+
+        $foo = new IncomingIlluminateRequest($request);
+        $this->assertNull($foo->getRequestHeader('header'));
+    }
+}


### PR DESCRIPTION
For example, 

`&amp;$skipToken=`

 is being exploded, trimming the leading &,
but leaving the rest of the html expansion in place.  This causes problems
further inside the library, which is expecting $skipToken => 'foo', not
the debris-encrusted version.