### PR TITLE
Rewrite null-removal checks in writeBagValue

### DIFF
--- a/src/POData/ObjectModel/ObjectModelSerializer.php
+++ b/src/POData/ObjectModel/ObjectModelSerializer.php
@@ -616,22 +616,23 @@ class ObjectModelSerializer extends ObjectModelSerializerBase implements IObject
             $odataProperty->value = null;
         } else {
             $odataBagContent = new ODataBagContent();
-            // strip out null elements
-            $BagValue = array_diff($BagValue, [null]);
             foreach ($BagValue as $itemValue) {
-                if (ResourceTypeKind::PRIMITIVE == $bagItemResourceTypeKind) {
-                    $odataBagContent->propertyContents[] = $this->primitiveToString($resourceType, $itemValue);
-                } elseif (ResourceTypeKind::COMPLEX == $bagItemResourceTypeKind) {
-                    $complexContent = new ODataPropertyContent();
-                    $this->complexObjectToContent(
-                        $itemValue,
-                        $propertyName,
-                        $resourceType,
-                        $relativeUri,
-                        $complexContent
-                    );
-                    //TODO add type in case of base type
-                    $odataBagContent->propertyContents[] = $complexContent;
+                // strip out null elements
+                if (isset($itemValue)) {
+                    if (ResourceTypeKind::PRIMITIVE == $bagItemResourceTypeKind) {
+                        $odataBagContent->propertyContents[] = $this->primitiveToString($resourceType, $itemValue);
+                    } elseif (ResourceTypeKind::COMPLEX == $bagItemResourceTypeKind) {
+                        $complexContent = new ODataPropertyContent();
+                        $this->complexObjectToContent(
+                            $itemValue,
+                            $propertyName,
+                            $resourceType,
+                            $relativeUri,
+                            $complexContent
+                        );
+                        //TODO add type in case of base type
+                        $odataBagContent->propertyContents[] = $complexContent;
+                    }
                 }
             }
 


### PR DESCRIPTION
On PHP 7.0 (at least), non-scalar bag values can and do cause problems
becuase array_diff seems to be trying to convert them to a string - especially
if the non-scalar in question lacks a toString method.