### PR TITLE
Fix variable interpolation

### DIFF
--- a/src/POData/Common/Messages/common.php
+++ b/src/POData/Common/Messages/common.php
@@ -15,7 +15,8 @@ trait common
      */
     public static function commonArgumentShouldBeInteger($argument, $functionName)
     {
-        return "The argument to the function '$functionName' should be integer, non-integer value '$argument' passed";
+        return 'The argument to the function '.$functionName.' should be integer, non-integer value \''
+               .$argument.'\' passed';
     }
 
     /**
@@ -29,7 +30,8 @@ trait common
      */
     public static function commonArgumentShouldBeNonNegative($argument, $functionName)
     {
-        return "The argument to the function '$functionName' should be non-negative, negative value '$argument' passed";
+        return 'The argument to the function '.$functionName.' should be non-negative, negative value \''
+               .$argument.'\' passed';
     }
 
     /**
@@ -43,7 +45,7 @@ trait common
      */
     public static function commonNotValidPrimitiveEDMType($argumentName, $functionName)
     {
-        return "The argument '$argumentName' to $functionName is not a valid EdmPrimitiveType Enum value.";
+        return 'The argument \''.$argumentName.'\' to '.$functionName.' is not a valid EdmPrimitiveType Enum value.';
     }
 
     /**
@@ -68,7 +70,7 @@ trait common
      */
     public static function failedToAccessProperty($propertyName, $parentObjectName)
     {
-        return "Data Service failed to access or initialize the property $propertyName of $parentObjectName.";
+        return 'Data Service failed to access or initialize the property '.$propertyName.' of '.$parentObjectName.'.';
     }
 
     /**
@@ -78,7 +80,7 @@ trait common
      */
     public static function orderByLeafNodeArgumentShouldBeNonEmptyArray()
     {
-        return 'There should be atleast one anscestor for building the sort function';
+        return 'There should be at least one ancestor for building the sort function';
     }
 
     /**
@@ -91,7 +93,9 @@ trait common
      */
     public static function badRequestInvalidPropertyNameSpecified($resourceTypeName, $propertyName)
     {
-        return "Error processing request stream. The property name '$propertyName' specified for type '$resourceTypeName' is not valid. (Check the resource set of the navigation property '$propertyName' is visible)";
+        return 'Error processing request stream. The property name '.$propertyName.' specified for type '
+               .$resourceTypeName.' is not valid. (Check the resource set of the navigation property \''
+               .$propertyName.'\' is visible)';
     }
 
     /**
@@ -102,6 +106,6 @@ trait common
      */
     public static function anonymousFunctionParameterShouldStartWithDollarSymbol()
     {
-        return 'The parameter names in parameter array should start with dollar symbol';
+        return 'The parameter names in parameter array should start with a dollar symbol';
     }
 }

--- a/src/POData/Common/Messages/configuration.php
+++ b/src/POData/Common/Messages/configuration.php
@@ -12,7 +12,8 @@ trait configuration
      */
     public static function configurationMaxResultAndPageSizeMutuallyExclusive()
     {
-        return 'Specification of \'entity set page size\' is mutually exclusive with the specification of \'maximum result per collection\' in configuration';
+        return 'Specification of \'entity set page size\' is mutually exclusive with the specification '
+               .'of \'maximum result per collection\' in configuration';
     }
 
     /**
@@ -25,7 +26,7 @@ trait configuration
      */
     public static function configurationResourceSetNameNotFound($name)
     {
-        return "The given name '$name' was not found in the entity sets";
+        return 'The given name \''.$name.'\' was not found in the entity sets';
     }
 
     /**
@@ -39,7 +40,7 @@ trait configuration
      */
     public static function configurationRightsAreNotInRange($argument, $functionName)
     {
-        return "The argument '$argument' of '$functionName' should be EntitySetRights enum value";
+        return 'The argument \''.$argument.'\' of \''.$functionName.'\' should be EntitySetRights enum value';
     }
 
     /**
@@ -50,7 +51,8 @@ trait configuration
      */
     public static function configurationCountNotAccepted()
     {
-        return 'The ability of the data service to return row count information is disabled. To enable this functionality, set the ServiceConfiguration.AcceptCountRequests property to true.';
+        return 'The ability of the data service to return row count information is disabled. To enable'
+               .' this functionality, set the ServiceConfiguration.AcceptCountRequests property to true.';
     }
 
     /**
@@ -61,6 +63,8 @@ trait configuration
      */
     public static function configurationProjectionsNotAccepted()
     {
-        return 'The ability to use the $select query option to define a projection in a data service query is disabled. To enable this functionality, call ServiceConfiguration::setAcceptProjectionRequests method with argument as true.';
+        return 'The ability to use the $select query option to define a projection in a data service query is'
+               .' disabled. To enable this functionality, call ServiceConfiguration::setAcceptProjectionRequests'
+               .' method with argument as true.';
     }
 }

--- a/src/POData/Common/Messages/eTag.php
+++ b/src/POData/Common/Messages/eTag.php
@@ -12,7 +12,8 @@ trait eTag
      */
     public static function eTagNotAllowedForNonExistingResource()
     {
-        return 'The resource targeted by the request does not exists, eTag header is not allowed for non-existing resource.';
+        return 'The resource targeted by the request does not exists, eTag header is not allowed for'
+               .' non-existing resource.';
     }
 
     /**
@@ -23,7 +24,8 @@ trait eTag
      */
     public static function noETagPropertiesForType()
     {
-        return 'If-Match or If-None-Match headers cannot be specified if the target type does not have etag properties defined.';
+        return 'If-Match or If-None-Match headers cannot be specified if the target type does not have'
+               .' etag properties defined.';
     }
 
     /**
@@ -47,6 +49,8 @@ trait eTag
      */
     public static function eTagCannotBeSpecified($uri)
     {
-        return "If-Match or If-None-Match HTTP headers cannot be specified since the URI '$uri' refers to a collection of resources or has a \$count or \$link segment or has a \$expand as one of the query parameters.";
+        return 'If-Match or If-None-Match HTTP headers cannot be specified since the URI \''.$uri.'\' refers to a'
+               .' collection of resources or has a $count or $link segment or has an $expand as one of the query'
+               .' parameters.';
     }
 }

--- a/src/POData/Common/Messages/expandProjectionParser.php
+++ b/src/POData/Common/Messages/expandProjectionParser.php
@@ -12,7 +12,8 @@ trait expandProjectionParser
      */
     public static function expandedProjectionNodeArgumentTypeShouldBeProjection()
     {
-        return 'The argument to ExpandedProjectionNode::addNode should be either ProjectionNode or ExpandedProjectionNode';
+        return 'The argument to ExpandedProjectionNode::addNode should be either ProjectionNode or'
+               .' ExpandedProjectionNode';
     }
 
     /**
@@ -31,7 +32,8 @@ trait expandProjectionParser
     {
         $clause = $isSelect ? 'select' : 'expand';
 
-        return  "Error in the $clause clause. Type '$resourceTypeName' does not have a property named '$propertyName'.";
+        return 'Error in the '.$clause.' clause. Type \''.$resourceTypeName.'\' does not have a property named \''
+               .$propertyName.'\'.';
     }
 
     /**
@@ -45,7 +47,8 @@ trait expandProjectionParser
      */
     public static function expandProjectionParserExpandCanOnlyAppliedToEntity($resourceTypeName, $propertyName)
     {
-        return  "Error in the expand clause. Expand path can contain only navigation property, the property '$propertyName' defined in '$resourceTypeName' is not a navigation property";
+        return 'Error in the expand clause. Expand path can contain only navigation property, the property '.
+               '\''.$propertyName.'\' defined in \''.$resourceTypeName.'\' is not a navigation property';
     }
 
     /**
@@ -61,7 +64,8 @@ trait expandProjectionParser
      */
     public static function expandProjectionParserPrimitivePropertyUsedAsNavigationProperty($resourceTypeName, $primitvePropertyName)
     {
-        return "Property '$primitvePropertyName' on type '$resourceTypeName' is of primitive type and cannot be used as a navigation property.";
+        return 'Property \''.$primitvePropertyName.'\' on type \''.$resourceTypeName
+               .'\' is of primitive type and cannot be used as a navigation property.';
     }
 
     /**
@@ -76,7 +80,8 @@ trait expandProjectionParser
      */
     public static function expandProjectionParserComplexPropertyAsInnerSelectSegment($resourceTypeName, $complextTypeName)
     {
-        return "select doesn't support selection of properties of complex type. The property '$complextTypeName' on type '$resourceTypeName' is a complex type.";
+        return 'select doesn\'t support selection of properties of complex type. The property \''.$complextTypeName
+               .'\' on type \''.$resourceTypeName.'\' is a complex type.';
     }
 
     /**
@@ -91,7 +96,8 @@ trait expandProjectionParser
      */
     public static function expandProjectionParserBagPropertyAsInnerSelectSegment($resourceTypeName, $bagPropertyName)
     {
-        return "The selection from property '$bagPropertyName' on type '$resourceTypeName' is not valid. The select query option does not support selection items from a bag property.";
+        return 'The selection from property \''.$bagPropertyName.'\' on type \''.$resourceTypeName
+               .'\' is not valid. The select query option does not support selection items from a bag property.';
     }
 
     /**
@@ -116,6 +122,7 @@ trait expandProjectionParser
      */
     public static function expandProjectionParserPropertyWithoutMatchingExpand($propertyName)
     {
-        return 'Only navigation properties specified in expand option can be travered in select option,In order to treaverse the navigation property \'' . $propertyName . '\', it should be first expanded';
+        return 'Only navigation properties specified in expand option can be traversed in select option.  In order to'
+               .' traverse the navigation property \'' . $propertyName . '\', it should be first expanded';
     }
 }

--- a/src/POData/Common/Messages/expressionLexer.php
+++ b/src/POData/Common/Messages/expressionLexer.php
@@ -51,7 +51,7 @@ trait expressionLexer
      */
     public static function expressionLexerInvalidCharacter($ch, $pos)
     {
-        return "Invalid character '$ch' at position $pos";
+        return 'Invalid character \''.$ch.'\' at position '.$pos;
     }
 
     /**
@@ -68,7 +68,8 @@ trait expressionLexer
         $protoTypes,
         $position
     ) {
-        return "No applicable function found for '$functionName' at position $position with the specified arguments. The functions considered are: $protoTypes";
+        return 'No applicable function found for \''.$functionName.'\' at position '.$position.' with the specified'
+               .' arguments. The functions considered are: '.$protoTypes;
     }
 
     /**
@@ -82,6 +83,6 @@ trait expressionLexer
      */
     public static function expressionLexerNoPropertyInType($property, $type, $position)
     {
-        return "No property '$property' exists in type '$type' at position $position";
+        return 'No property \''.$property.'\' exists in type \''.$type.'\' at position '.$position;
     }
 }

--- a/src/POData/Common/Messages/expressionParser.php
+++ b/src/POData/Common/Messages/expressionParser.php
@@ -15,7 +15,7 @@ trait expressionParser
      */
     public static function expressionParserInCompatibleTypes($operator, $str, $pos)
     {
-        return "Operator '$operator' incompatible with operand types $str at position $pos";
+        return 'Operator \''.$operator.'\' incompatible with operand types '.$str.' at position '.$pos;
     }
 
     /**
@@ -28,7 +28,8 @@ trait expressionParser
      */
     public static function expressionParserOperatorNotSupportNull($operator, $pos)
     {
-        return "The operator '$operator' at position $pos is not supported for the 'null' literal; only equality checks are supported";
+        return 'The operator \''.$operator.'\' at position '.$pos.' is not supported for the \'null\''
+               .' literal; only equality checks are supported';
     }
 
     /**
@@ -41,7 +42,8 @@ trait expressionParser
      */
     public static function expressionParserOperatorNotSupportGuid($operator, $pos)
     {
-        return "The operator '$operator' at position $pos is not supported for the Edm.Guid ; only equality checks are supported";
+        return 'The operator \''.$operator.'\' at position '.$pos.' is not supported for the Edm.Guid;'
+               .' only equality checks are supported';
     }
 
     /**
@@ -54,7 +56,8 @@ trait expressionParser
      */
     public static function expressionParserOperatorNotSupportBinary($operator, $pos)
     {
-        return "The operator '$operator' at position $pos is not supported for the Edm.Binary ; only equality checks are supported";
+        return 'The operator \''.$operator.'\' at position '.$pos.' is not supported for the Edm.Binary;'
+               .' only equality checks are supported';
     }
 
     /**
@@ -68,7 +71,7 @@ trait expressionParser
      */
     public static function expressionParserUnrecognizedLiteral($type, $literal, $pos)
     {
-        return "Unrecognized '$type' literal '$literal' in position '$pos'.";
+        return 'Unrecognized \''.$type.'\' literal \''.$literal.'\' in position \''.$pos.'\'.';
     }
 
     /**
@@ -81,7 +84,7 @@ trait expressionParser
      */
     public static function expressionParserUnknownFunction($str, $pos)
     {
-        return "Unknown function '$str' at position $pos";
+        return 'Unknown function \''.$str.'\' at position '.$pos;
     }
 
     /**
@@ -103,7 +106,7 @@ trait expressionParser
      */
     public static function expressionParser2UnexpectedExpression($expressionClassName)
     {
-        return "Unexpected expression of type \'$expressionClassName\' found";
+        return 'Unexpected expression of type \''.$expressionClassName.'\' found';
     }
 
     /**
@@ -128,6 +131,7 @@ trait expressionParser
      */
     public static function expressionParserEntityCollectionNotAllowedInFilter($property, $parentProperty, $pos)
     {
-        return "The '$property' is an entity collection property of '$parentProperty' (position: $pos), which cannot be used in \$filter query option";
+        return 'The \''.$property.'\' is an entity collection property of \''.$parentProperty.'\' (position: '.$pos
+               .'), which cannot be used in $filter query option';
     }
 }

--- a/src/POData/Common/Messages/http.php
+++ b/src/POData/Common/Messages/http.php
@@ -16,7 +16,8 @@ trait http
     public static function hostMalFormedBaseUriInConfig($notEndWithSvcOrHasQuery = false)
     {
         if ($notEndWithSvcOrHasQuery) {
-            return 'Malformed base service uri in the configuration file (should end with .svc, there should not be query or fragment in the base service uri)';
+            return 'Malformed base service uri in the configuration file (should end with .svc, there should not'.
+                   ' be query or fragment in the base service uri)';
         }
 
         return 'Malformed base service uri in the configuration file';
@@ -33,7 +34,8 @@ trait http
      */
     public static function hostRequestUriIsNotBasedOnRelativeUriInConfig($requestUri, $relativeUri)
     {
-        return 'The request uri ' . $requestUri . ' is not valid as it is not based on the configured relative uri ' . $relativeUri;
+        return 'The request uri ' . $requestUri . ' is not valid as it is not based on the configured relative uri '
+               . $relativeUri;
     }
 
     /**
@@ -46,7 +48,7 @@ trait http
     public static function onlyReadSupport(HTTPRequestMethod $method)
     {
         // TODO: Update to reflect expanded library capabilities?
-        return "This release of library supports only GET (read) request, received a request with method $method";
+        return 'This release of library supports only GET (read) request, received a request with method '. $method;
     }
 
     /**
@@ -59,7 +61,7 @@ trait http
      */
     public static function badRequestInvalidUriForThisVerb($uri, $verb)
     {
-        return "The URI '$uri' is not valid for $verb method.";
+        return 'The URI \''.$uri.'\' is not valid for '.$verb.' method.';
     }
 
     /**
@@ -71,7 +73,7 @@ trait http
      */
     public static function noDataForThisVerb($verb)
     {
-        return "Method $verb expecting some data, but received empty data.";
+        return 'Method '.$verb.' expecting some data, but received empty data.';
     }
 
     /**
@@ -84,7 +86,8 @@ trait http
      */
     public static function badRequestInvalidUriForMediaResource($uri)
     {
-        return "The URI '$uri' is not valid. The segment before '\$value' must be a Media Link Entry or a primitive property.";
+        return 'The URI \''.$uri.'\' is not valid. The segment before \'$value\' must be a Media Link Entry or'
+               .' a primitive property.';
     }
 
     /**
@@ -97,7 +100,8 @@ trait http
      */
     public static function hostNonODataOptionBeginsWithSystemCharacter($optionName)
     {
-        return "The query parameter '$optionName' begins with a system-reserved '$' character but is not recognized.";
+        return 'The query parameter \''.$optionName.'\' begins with a system-reserved \'$\' character but'
+               .' is not recognized.';
     }
 
     /**
@@ -110,7 +114,7 @@ trait http
      */
     public static function hostODataQueryOptionFoundWithoutValue($optionName)
     {
-        return "Query parameter '$optionName' is specified, but it should be specified with value.";
+        return 'Query parameter \''.$optionName.'\' is specified, but it should be specified with value.';
     }
 
     /**
@@ -123,7 +127,7 @@ trait http
      */
     public static function hostODataQueryOptionCannotBeSpecifiedMoreThanOnce($optionName)
     {
-        return "Query parameter '$optionName' is specified, but it should be specified exactly once.";
+        return 'Query parameter \''.$optionName.'\' is specified, but it should be specified exactly once.';
     }
 
     /**
@@ -134,6 +138,7 @@ trait http
      */
     public static function bothIfMatchAndIfNoneMatchHeaderSpecified()
     {
-        return 'Both If-Match and If-None-Match HTTP headers cannot be specified at the same time. Please specify either one of the headers or none of them.';
+        return 'Both If-Match and If-None-Match HTTP headers cannot be specified at the same time. Please specify'
+               .' either one of the headers or none of them.';
     }
 }

--- a/src/POData/Common/Messages/httpProcessUtility.php
+++ b/src/POData/Common/Messages/httpProcessUtility.php
@@ -11,7 +11,7 @@ trait httpProcessUtility
      */
     public static function httpProcessUtilityMediaTypeRequiresSemicolonBeforeParameter()
     {
-        return "Media type requires a ';' character before a parameter definition.";
+        return 'Media type requires a \';\' character before a parameter definition.';
     }
 
     /**
@@ -31,7 +31,7 @@ trait httpProcessUtility
      */
     public static function httpProcessUtilityMediaTypeRequiresSlash()
     {
-        return "Media type requires a '/' character.";
+        return 'Media type requires a \'/\' character.';
     }
 
     /**
@@ -64,7 +64,8 @@ trait httpProcessUtility
      */
     public static function httpProcessUtilityEscapeCharWithoutQuotes($parameterName)
     {
-        return "Value for MIME type parameter '$parameterName' is incorrect because it contained escape characters even though it was not quoted.";
+        return 'Value for MIME type parameter \''.$parameterName.'\' is incorrect because it contained escape'.
+               ' characters even though it was not quoted.';
     }
 
     /**
@@ -77,7 +78,8 @@ trait httpProcessUtility
      */
     public static function httpProcessUtilityEscapeCharAtEnd($parameterName)
     {
-        return "Value for MIME type parameter '$parameterName' is incorrect because it terminated with escape character. Escape characters must always be followed by a character in a parameter value.";
+        return 'Value for MIME type parameter \''.$parameterName.'\' is incorrect because it terminated with escape'
+               .' character. Escape characters must always be followed by a character in a parameter value.';
     }
 
     /**
@@ -90,7 +92,8 @@ trait httpProcessUtility
      */
     public static function httpProcessUtilityClosingQuoteNotFound($parameterName)
     {
-        return "Value for MIME type parameter '$parameterName' is incorrect because the closing quote character could not be found while the parameter value started with a quote character.";
+        return 'Value for MIME type parameter \''.$parameterName.'\' is incorrect because the closing quote character'
+               .' could not be found while the parameter value started with a quote character.';
     }
 
     /**

--- a/src/POData/Common/Messages/keyDescriptor.php
+++ b/src/POData/Common/Messages/keyDescriptor.php
@@ -16,7 +16,8 @@ trait keyDescriptor
      */
     public static function keyDescriptorKeyCountNotMatching($segment, $expectedCount, $actualCount)
     {
-        return "The predicate in the segment '$segment' expect $expectedCount keys but $actualCount provided";
+        return 'The predicate in the segment \''.$segment.'\' expect '.$expectedCount.' keys but '.$actualCount
+               .' provided';
     }
 
     /**
@@ -30,7 +31,8 @@ trait keyDescriptor
      */
     public static function keyDescriptorMissingKeys($segment, $expectedKeys)
     {
-        return "Missing keys in key predicate for the segment '$segment'. The key predicate expect the keys '$expectedKeys'";
+        return 'Missing keys in key predicate for the segment \''.$segment.'\'. The key predicate expects the keys \''
+               .$expectedKeys.'\'';
     }
 
     /**
@@ -46,7 +48,8 @@ trait keyDescriptor
      */
     public static function keyDescriptorInCompatibleKeyType($segment, $keyProperty, $expectedType, $actualType)
     {
-        return "Syntax error in the segment '$segment'. The value of key property '$keyProperty' should be of type " . $expectedType . ', given ' . $actualType;
+        return 'Syntax error in the segment \''.$segment.'\'. The value of key property \''.$keyProperty
+               .'\' should be of type ' . $expectedType . ', given ' . $actualType;
     }
 
     /**
@@ -63,7 +66,8 @@ trait keyDescriptor
      */
     public static function keyDescriptorInCompatibleKeyTypeAtPosition($segment, $keyProperty, $position, $expectedType, $actualType)
     {
-        return "Syntax error in the segment '$segment'. The value of key property '$keyProperty' at position $position should be of type " . $expectedType . ', given ' . $actualType;
+        return 'Syntax error in the segment \''.$segment.'\'. The value of key property \''.$keyProperty
+               .'\' at position '.$position.' should be of type ' . $expectedType . ', given ' . $actualType;
     }
 
     /**

--- a/src/POData/Common/Messages/metadataAssociationType.php
+++ b/src/POData/Common/Messages/metadataAssociationType.php
@@ -14,7 +14,8 @@ trait metadataAssociationType
      */
     public static function metadataAssociationTypeSetBidirectionalAssociationMustReturnSameResourceAssociationSetFromBothEnd()
     {
-        return 'When the ResourceAssociationSet is bidirectional, IMetadataProvider::getResourceAssociationSet() must return the same ResourceAssociationSet when call from both ends.';
+        return 'When the ResourceAssociationSet is bidirectional, IMetadataProvider::getResourceAssociationSet() must'.
+               ' return the same ResourceAssociationSet when call from both ends.';
     }
 
     /**
@@ -30,7 +31,11 @@ trait metadataAssociationType
      */
     public static function metadataAssociationTypeSetMultipleAssociationSetsForTheSameAssociationTypeMustNotReferToSameEndSets($resourceSet1Name, $resourceSet2Name, $entitySetName)
     {
-        return "ResourceAssociationSets '$resourceSet1Name' and '$resourceSet2Name' have a ResourceAssociationSetEnd referring to the same EntitySet '$entitySetName' through the same AssociationType. Make sure that if two or more AssociationSets refer to the same AssociationType, the ends must not refer to the same EntitySet. (this could happen if multiple entity sets have entity types that have a common ancestor and the ancestor has a property of derived entity types)";
+        return 'ResourceAssociationSets \''.$resourceSet1Name.'\' and \''.$resourceSet2Name.'\' have a'
+               .' ResourceAssociationSetEnd referring to the same EntitySet \''.$entitySetName.'\' through the same'
+               .' AssociationType. Make sure that if two or more AssociationSets refer to the same AssociationType,'
+               .' the ends must not refer to the same EntitySet. (this could happen if multiple entity sets have'
+               .' entity types that have a common ancestor and the ancestor has a property of derived entity types)';
     }
 
     /**
@@ -43,6 +48,7 @@ trait metadataAssociationType
      */
     public static function metadataAssociationTypeSetInvalidGetDerivedTypesReturnType($resourceTypeName)
     {
-        return "Return type of IDSMP::getDerivedTypes should be either null or array of 'ResourceType', check implementation of IDSMP::getDerivedTypes for the resource type '$resourceTypeName'.";
+        return 'Return type of IDSMP::getDerivedTypes should be either null or array of \'ResourceType\', check'
+               .' implementation of IDSMP::getDerivedTypes for the resource type \''.$resourceTypeName.'\'.';
     }
 }

--- a/src/POData/Common/Messages/metadataResourceType.php
+++ b/src/POData/Common/Messages/metadataResourceType.php
@@ -15,7 +15,9 @@ trait metadataResourceType
      */
     public static function metadataResourceTypeSetNamedStreamsOnDerivedEntityTypesNotSupported($entitySetName, $derivedTypeName)
     {
-        return "Named streams are not supported on derived entity types. Entity Set '$entitySetName' has a instance of type '$derivedTypeName', which is an derived entity type and has named streams. Please remove all named streams from type '$derivedTypeName'.";
+        return 'Named streams are not supported on derived entity types. Entity Set \''.$entitySetName
+               .'\' has an instance of type \''.$derivedTypeName.'\', which is a derived entity type and has'
+               .' named streams. Please remove all named streams from type \''.$derivedTypeName.'\'.';
     }
 
     /**
@@ -29,6 +31,7 @@ trait metadataResourceType
      */
     public static function metadataResourceTypeSetBagOfComplexTypeWithDerivedTypes($complexTypeName)
     {
-        return "Complex type '$complexTypeName' has derived types and is used as the item type in a bag. Only bags containing complex types without derived types are supported.";
+        return 'Complex type \''.$complexTypeName.'\' has derived types and is used as the item type in a bag.'
+               .' Only bags containing complex types without derived types are supported.';
     }
 }

--- a/src/POData/Common/Messages/metadataWriter.php
+++ b/src/POData/Common/Messages/metadataWriter.php
@@ -27,6 +27,8 @@ trait metadataWriter
      */
     public static function metadataWriterNoResourceAssociationSetForNavigationProperty($navigationPropertyName, $resourceTypeName)
     {
-        return "No visible ResourceAssociationSet found for navigation property '$navigationPropertyName' on type '$resourceTypeName'. There must be at least one ResourceAssociationSet for each navigation property.";
+        return 'No visible ResourceAssociationSet found for navigation property \''.$navigationPropertyName.
+               '\' on type \''.$resourceTypeName.'\'. There must be at least one ResourceAssociationSet for'.
+               ' each navigation property.';
     }
 }

--- a/src/POData/Common/Messages/navigation.php
+++ b/src/POData/Common/Messages/navigation.php
@@ -33,6 +33,6 @@ trait navigation
      */
     public static function urlMalformedUrl($url)
     {
-        return "Bad Request - The url '$url' is malformed.";
+        return 'Bad Request - The url \''.$url.'\' is malformed.';
     }
 }

--- a/src/POData/Common/Messages/objectModelSerializer.php
+++ b/src/POData/Common/Messages/objectModelSerializer.php
@@ -15,7 +15,7 @@ trait objectModelSerializer
      */
     public static function badProviderInconsistentEntityOrComplexTypeUsage($typeName)
     {
-        return "Internal Server Error. The type '$typeName' has inconsistent metadata and runtime type info.";
+        return 'Internal Server Error. The type \''.$typeName.'\' has inconsistent metadata and runtime type info.';
     }
 
     /**
@@ -30,7 +30,8 @@ trait objectModelSerializer
      */
     public static function badQueryNullKeysAreNotSupported($resourceTypeName, $keyName)
     {
-        return "The serialized resource of type $resourceTypeName has a null value in key member '$keyName'. Null values are not supported in key members.";
+        return 'The serialized resource of type '.$resourceTypeName.' has a null value in key member \''.$keyName
+               .'\'. Null values are not supported in key members.';
     }
 
     /**
@@ -44,7 +45,8 @@ trait objectModelSerializer
      */
     public static function objectModelSerializerFailedToAccessProperty($propertyName, $parentObjectName)
     {
-        return "objectModelSerializer failed to access or initialize the property $propertyName of $parentObjectName, Please contact provider.";
+        return 'objectModelSerializer failed to access or initialize the property '.$propertyName.' of '
+               .$parentObjectName.', Please contact provider.';
     }
 
     /**
@@ -57,6 +59,7 @@ trait objectModelSerializer
      */
     public static function objectModelSerializerLoopsNotAllowedInComplexTypes($complexPropertyName)
     {
-        return 'A circular loop was detected while serializing the property \'' . $complexPropertyName . '\'. You must make sure that loops are not present in properties that return a bag or complex type.';
+        return 'A circular loop was detected while serializing the property \'' . $complexPropertyName
+               . '\'. You must make sure that loops are not present in properties that return a bag or complex type.';
     }
 }

--- a/src/POData/Common/Messages/orderByInfo.php
+++ b/src/POData/Common/Messages/orderByInfo.php
@@ -49,7 +49,7 @@ trait orderByInfo
      */
     public static function orderByParserPropertyNotFound($resourceTypeName, $propertyName)
     {
-        return  "Error in the 'orderby' clause. Type '$resourceTypeName' does not have a property named '$propertyName'.";
+        return 'Error in the \'orderby\' clause. Type '.$resourceTypeName.' does not have a property named \''.$propertyName.'\'.';
     }
 
     /**
@@ -62,7 +62,8 @@ trait orderByInfo
      */
     public static function orderByParserBagPropertyNotAllowed($bagPropertyName)
     {
-        return "orderby clause does not support Bag property in the path, the property '$bagPropertyName' is a bag property";
+        return 'orderby clause does not support Bag property in the path, the property \''.$bagPropertyName
+               .'\' is a bag property';
     }
 
     /**
@@ -75,7 +76,8 @@ trait orderByInfo
      */
     public static function orderByParserPrimitiveAsIntermediateSegment($propertyName)
     {
-        return "The primitive property '$propertyName' cannnot be used as intermediate segment, it should be last segment";
+        return 'The primitive property \''.$propertyName.'\' cannnot be used as intermediate segment, it should'
+               .' be last segment';
     }
 
     /**
@@ -87,7 +89,7 @@ trait orderByInfo
      */
     public static function orderByParserSortByBinaryPropertyNotAllowed($binaryPropertyName)
     {
-        return "Binary property is not allowed in orderby clause, '$binaryPropertyName'";
+        return 'Binary property is not allowed in orderby clause, \''.$binaryPropertyName.'\'';
     }
 
     /**
@@ -101,7 +103,8 @@ trait orderByInfo
      */
     public static function orderByParserResourceSetReferenceNotAllowed($propertyName, $definedType)
     {
-        return "Navigation property points to a collection cannot be used in orderby clause, The property '$propertyName' defined on type '$definedType' is such a property";
+        return 'Navigation property points to a collection cannot be used in orderby clause, The property \''
+               .$propertyName.'\' defined on type \''.$definedType.'\' is such a property';
     }
 
     /**
@@ -114,7 +117,7 @@ trait orderByInfo
      */
     public static function orderByParserSortByNavigationPropertyIsNotAllowed($navigationPropertyName)
     {
-        return "Navigation property cannot be used as sort key, '$navigationPropertyName'";
+        return 'Navigation property cannot be used as sort key, \''.$navigationPropertyName.'\'';
     }
 
     /**
@@ -127,7 +130,8 @@ trait orderByInfo
      */
     public static function orderByParserSortByComplexPropertyIsNotAllowed($complexPropertyName)
     {
-        return "Complex property cannot be used as sort key, the property '$complexPropertyName' is a complex property";
+        return 'Complex property cannot be used as sort key, the property \''.$complexPropertyName
+               .'\' is a complex property';
     }
 
     /**
@@ -173,6 +177,6 @@ trait orderByInfo
      */
     public static function orderByParserFailedToAccessOrInitializeProperty($propertyName, $parentObjectName)
     {
-        return "OrderBy parser failed to access or initialize the property $propertyName of $parentObjectName";
+        return 'OrderBy parser failed to access or initialize the property '.$propertyName.' of '.$parentObjectName;
     }
 }

--- a/src/POData/Common/Messages/providersWrapper.php
+++ b/src/POData/Common/Messages/providersWrapper.php
@@ -11,7 +11,8 @@ trait providersWrapper
      */
     public static function providersWrapperNull()
     {
-        return 'For custom providers, GetService should not return null for both IMetadataProvider and IQueryProvider types.';
+        return 'For custom providers, GetService should not return null for both IMetadataProvider and'
+               .' IQueryProvider types.';
     }
 
     /**
@@ -33,7 +34,8 @@ trait providersWrapper
      */
     public static function providersWrapperInvalidExpressionProviderInstance()
     {
-        return 'The value returned by IQueryProvider::getExpressionProvider method must be an implementation of IExpressionProvider';
+        return 'The value returned by IQueryProvider::getExpressionProvider method must be an implementation'
+               .' of IExpressionProvider';
     }
 
     /**
@@ -69,7 +71,8 @@ trait providersWrapper
      */
     public static function providersWrapperEntitySetNameShouldBeUnique($entitySetName)
     {
-        return "More than one entity set with the name '$entitySetName' was found. Entity set names must be unique";
+        return 'More than one entity set with the name \''.$entitySetName
+               .'\' was found. Entity set names must be unique';
     }
 
     /**
@@ -82,7 +85,8 @@ trait providersWrapper
      */
     public static function providersWrapperEntityTypeNameShouldBeUnique($entityTypeName)
     {
-        return "More than one entity type with the name '$entityTypeName' was found. Entity type names must be unique.";
+        return 'More than one entity type with the name \''.$entityTypeName
+               .'\' was found. Entity type names must be unique';
     }
 
     /**
@@ -97,7 +101,9 @@ trait providersWrapper
      */
     public static function providersWrapperIDSMPGetResourceSetReturnsInvalidResourceSet($resourceSetName, $resourceTypeName, $resourcePropertyName)
     {
-        return "IDSMP::GetResourceSet retruns invalid instance of ResourceSet when invoked with params {ResourceSet with name $resourceSetName, ResourceType with name $resourceTypeName, ResourceProperty with name $resourcePropertyName}.";
+        return 'IDSMP::GetResourceSet retruns invalid instance of ResourceSet when invoked with params'.
+               ' {ResourceSet with name '.$resourceSetName.', ResourceType with name '.$resourceTypeName
+               .', ResourceProperty with name '.$resourcePropertyName.'}.';
     }
 
     /**
@@ -111,7 +117,8 @@ trait providersWrapper
      */
     public static function providersWrapperIDSQPMethodReturnsUnExpectedType($entityTypeName, $methodName)
     {
-        return 'The implementation of the method ' . $methodName . ' must return an instance of type described by resource set\'s type(' . $entityTypeName . ') or null if resource does not exist.';
+        return 'The implementation of the method ' . $methodName . ' must return an instance of type described'
+               .' by resource set\'s type(' . $entityTypeName . ') or null if resource does not exist.';
     }
 
     /**

--- a/src/POData/Common/Messages/queryProcessor.php
+++ b/src/POData/Common/Messages/queryProcessor.php
@@ -24,7 +24,8 @@ trait queryProcessor
      */
     public static function queryProcessorNoQueryOptionsApplicable()
     {
-        return 'Query options $select, $expand, $filter, $orderby, $inlinecount, $skip, $skiptoken and $top are not supported by this request method or cannot be applied to the requested resource.';
+        return 'Query options $select, $expand, $filter, $orderby, $inlinecount, $skip, $skiptoken and $top are not'.
+               ' supported by this request method or cannot be applied to the requested resource.';
     }
 
     /**
@@ -107,7 +108,7 @@ trait queryProcessor
      */
     public static function queryProcessorIncorrectArgumentFormat($argName, $argValue)
     {
-        return "Incorrect format for $argName argument '$argValue'";
+        return 'Incorrect format for '.$argName.' argument \''.$argValue.'\'';
     }
 
     /**
@@ -121,7 +122,8 @@ trait queryProcessor
      */
     public static function queryProcessorSkipTokenCannotBeAppliedForNonPagedResourceSet($resourceSetName)
     {
-        return "\$skiptoken cannot be applied to the resource set '$resourceSetName', since paging is not enabled for this resource set";
+        return '$skiptoken cannot be applied to the resource set \''.$resourceSetName
+               .'\', since paging is not enabled for this resource set';
     }
 
     /**
@@ -135,6 +137,6 @@ trait queryProcessor
      */
     public static function queryProcessorSelectOrExpandOptionNotApplicable($queryItem)
     {
-        return "Query option $queryItem cannot be applied to the requested resource";
+        return 'Query option '.$queryItem.' cannot be applied to the requested resource';
     }
 }

--- a/src/POData/Common/Messages/queryProvider.php
+++ b/src/POData/Common/Messages/queryProvider.php
@@ -13,7 +13,7 @@ trait queryProvider
      */
     public static function queryProviderReturnsNonQueryResult($methodName)
     {
-        return "The implementation of the method $methodName must return a QueryResult instance.";
+        return 'The implementation of the method '.$methodName.' must return a QueryResult instance.';
     }
 
     /**
@@ -24,7 +24,8 @@ trait queryProvider
      */
     public static function queryProviderResultCountMissing($methodName, QueryType $queryType)
     {
-        return "The implementation of the method $methodName must return a QueryResult instance with a count for queries of type $queryType.";
+        return 'The implementation of the method '.$methodName.' must return a QueryResult instance with a count for '
+               .'queries of type '.$queryType.'.';
     }
 
     /**
@@ -35,6 +36,7 @@ trait queryProvider
      */
     public static function queryProviderResultsMissing($methodName, QueryType $queryType)
     {
-        return "The implementation of the method $methodName must return a QueryResult instance with an array of results for queries of type $queryType.";
+        return 'The implementation of the method '.$methodName.' must return a QueryResult instance with an array'
+               .' of results for queries of type '.$queryType.'.';
     }
 }

--- a/src/POData/Common/Messages/request.php
+++ b/src/POData/Common/Messages/request.php
@@ -16,7 +16,8 @@ trait request
      */
     public static function requestVersionTooLow($requestedVersion, $requiredVersion)
     {
-        return "Request version '$requestedVersion' is not supported for the request payload. The only supported version is '$requiredVersion'.";
+        return 'Request version \''.$requestedVersion.'\' is not supported for the request payload. The only'
+               .' supported version is \''.$requiredVersion.'\'.';
     }
 
     /**
@@ -30,7 +31,8 @@ trait request
      */
     public static function requestVersionIsBiggerThanProtocolVersion($requiredVersion, $configuredVersion)
     {
-        return "The response requires that version $requiredVersion of the protocol be used, but the MaxProtocolVersion of the data service is set to $configuredVersion.";
+        return 'The response requires that version '.$requiredVersion.' of the protocol be used, but the'
+               .' MaxProtocolVersion of the data service is set to '.$configuredVersion.'.';
     }
 
     /**
@@ -44,7 +46,7 @@ trait request
      */
     public static function requestDescriptionInvalidVersionHeader($versionAsString, $headerName)
     {
-        return "The header $headerName has malformed version value $versionAsString";
+        return 'The header '.$headerName.' has malformed version value '.$versionAsString;
     }
 
     /**
@@ -59,6 +61,7 @@ trait request
      */
     public static function requestDescriptionUnSupportedVersion($requestHeaderName, $requestedVersion, $availableVersions)
     {
-        return "The version value $requestedVersion in the header $requestHeaderName is not supported, available versions are $availableVersions";
+        return 'The version value '.$requestedVersion.' in the header '.$requestHeaderName.' is not'
+               .' supported, available versions are '.$availableVersions;
     }
 }

--- a/src/POData/Common/Messages/resourceAssociationSet.php
+++ b/src/POData/Common/Messages/resourceAssociationSet.php
@@ -14,7 +14,7 @@ trait resourceAssociationSet
      */
     public static function resourceAssociationSetPropertyMustBeNullOrInstanceofResourceProperty($argumentName)
     {
-        return "The argument '$argumentName' must be either null or instance of 'ResourceProperty'.";
+        return 'The argument \''.$argumentName.'\' must be either null or instance of \'ResourceProperty\'.';
     }
 
     /**
@@ -28,7 +28,7 @@ trait resourceAssociationSet
      */
     public static function resourceAssociationSetEndPropertyMustBeNavigationProperty($propertyName, $resourceTypeName)
     {
-        return "The property $propertyName must be a navigation property of the resource type $resourceTypeName";
+        return 'The property '.$propertyName.' must be a navigation property of the resource type '.$resourceTypeName;
     }
 
     /**
@@ -42,7 +42,7 @@ trait resourceAssociationSet
      */
     public static function resourceAssociationSetEndResourceTypeMustBeAssignableToResourceSet($resourceTypeName, $resourceSetName)
     {
-        return "The resource type $resourceTypeName must be assignable to the resource set $resourceSetName.";
+        return 'The resource type '.$resourceTypeName.' must be assignable to the resource set '.$resourceSetName.'.';
     }
 
     /**

--- a/src/POData/Common/Messages/resourceAssociationType.php
+++ b/src/POData/Common/Messages/resourceAssociationType.php
@@ -14,7 +14,7 @@ trait resourceAssociationType
      */
     public static function resourceAssociationTypeEndPropertyMustBeNullOrInstanceofResourceProperty($argumentName)
     {
-        return "The argument '".$argumentName."' must be either null or instance of 'ResourceProperty'.";
+        return 'The argument \''.$argumentName.'\' must be either null or instance of \'ResourceProperty\'.';
     }
 
     /**

--- a/src/POData/Common/Messages/resourceProperty.php
+++ b/src/POData/Common/Messages/resourceProperty.php
@@ -13,7 +13,8 @@ trait resourceProperty
      */
     public static function resourcePropertyInvalidKindParameter($argumentName)
     {
-        return "The argument '$argumentName' is not a valid ResourcePropertyKind enum value or valid combination of ResourcePropertyKind enum values";
+        return 'The argument \''.$argumentName.'\' is not a valid ResourcePropertyKind enum value or'
+               .' valid combination of ResourcePropertyKind enum values';
     }
 
     /**
@@ -26,6 +27,7 @@ trait resourceProperty
      */
     public static function resourcePropertyPropertyKindAndResourceTypeKindMismatch($resourcePropertyKindArgName, $resourceTypeArgName)
     {
-        return "The '$resourcePropertyKindArgName' parameter does not match with the type of the resource type in parameter '$resourceTypeArgName'";
+        return 'The \''.$resourcePropertyKindArgName.'\' parameter does not match with the type of the resource'
+               .' type in parameter \''.$resourceTypeArgName.'\'';
     }
 }

--- a/src/POData/Common/Messages/resourceSet.php
+++ b/src/POData/Common/Messages/resourceSet.php
@@ -12,6 +12,7 @@ trait resourceSet
      */
     public static function resourceSetContainerMustBeAssociatedWithEntityType()
     {
-        return 'The ResourceTypeKind property of a ResourceType instance associated with a ResourceSet must be equal to \'EntityType\'';
+        return 'The ResourceTypeKind property of a ResourceType instance associated with a ResourceSet'
+               .' must be equal to \'EntityType\'';
     }
 }

--- a/src/POData/Common/Messages/resourceType.php
+++ b/src/POData/Common/Messages/resourceType.php
@@ -36,7 +36,7 @@ trait resourceType
      */
     public static function resourceTypeTypeShouldImplementIType($argument)
     {
-        return "For primitive type the '$argument' argument should be an 'IType' implementor instance";
+        return 'For primitive type the \''.$argument.'\' argument should be an \'IType\' instance';
     }
 
     /**
@@ -49,7 +49,7 @@ trait resourceType
      */
     public static function resourceTypeTypeShouldReflectionClass($argument)
     {
-        return "For entity type the '$argument' argument should be an 'ReflectionClass' instance";
+        return 'For entity type the \''.$argument.'\' argument should be a \'ReflectionClass\' instance';
     }
 
     /**
@@ -61,7 +61,8 @@ trait resourceType
      */
     public static function resourceTypeMissingKeyPropertiesForEntity($entityName)
     {
-        return "The entity type '$entityName' does not have any key properties. Please make sure the key properties are defined for this entity type";
+        return 'The entity type \''.$entityName.'\' does not have any key properties. Please make sure the key'
+               .' properties are defined for this entity type';
     }
 
     /**
@@ -83,7 +84,8 @@ trait resourceType
      */
     public static function resourceTypeKeyPropertiesOnlyOnEntityTypes()
     {
-        return 'Key properties can only be added to ResourceType instances with a ResourceTypeKind equal to \'EntityType\'';
+        return 'Key properties can only be added to ResourceType instances with a ResourceTypeKind'
+               .' equal to \'EntityType\'';
     }
 
     /**
@@ -94,7 +96,8 @@ trait resourceType
      */
     public static function resourceTypeETagPropertiesOnlyOnEntityTypes()
     {
-        return 'ETag properties can only be added to ResourceType instances with a ResourceTypeKind equal to \'EntityType\'';
+        return 'ETag properties can only be added to ResourceType instances with a ResourceTypeKind'
+               .' equal to \'EntityType\'';
     }
 
     /**
@@ -108,7 +111,9 @@ trait resourceType
      */
     public static function resourceTypePropertyWithSameNameAlreadyExists($propertyName, $resourceTypeName)
     {
-        return "Property with same name '$propertyName' already exists in type '$resourceTypeName'. Please make sure that there is no property with the same name defined in one of the ancestor types";
+        return 'Property with same name \''.$propertyName.'\' already exists in type \''.$resourceTypeName
+               .'\'. Please make sure that there is no property with the same name defined in one of the'
+               .' ancestor types';
     }
 
     /**
@@ -152,6 +157,8 @@ trait resourceType
      */
     public static function resourceTypeNamedStreamWithSameNameAlreadyExists($namedStreamName, $resourceTypeName)
     {
-        return "Named stream with the name '$namedStreamName' already exists in type '$resourceTypeName'. Please make sure that there is no named stream with the same name defined in one of the ancestor types";
+        return 'Named stream with the name \''.$namedStreamName.'\' already exists in type \''.$resourceTypeName
+               .'\'. Please make sure that there is no named stream with the same name defined in one of the'
+               .' ancestor types';
     }
 }

--- a/src/POData/Common/Messages/segmentParser.php
+++ b/src/POData/Common/Messages/segmentParser.php
@@ -14,7 +14,8 @@ trait segmentParser
      */
     public static function segmentParserKeysMustBeNamed($segment)
     {
-        return "Segments with multiple key values must specify them in 'name=value' form. For the segment $segment use named keys";
+        return 'Segments with multiple key values must specify them in \'name=value\' form. For the segment'
+               . $segment.' use named keys';
     }
 
     /**
@@ -28,7 +29,9 @@ trait segmentParser
      */
     public static function segmentParserMustBeLeafSegment($leafSegment)
     {
-        return "The request URI is not valid. The segment '$leafSegment' must be the last segment in the URI because it is one of the following: \$batch, \$value, \$metadata, \$count, a bag property, a named media resource, or a service operation that does not return a value.";
+        return 'The request URI is not valid. The segment \''.$leafSegment.'\' must be the last segment in'
+               .' the URI because it is one of the following: $batch, $value, $metadata, $count, a bag property,'
+               .' a named media resource, or a service operation that does not return a value.';
     }
 
     /**
@@ -40,7 +43,8 @@ trait segmentParser
      */
     public static function segmentParserNoSegmentAllowedAfterPostLinkSegment($postPostLinkSegment)
     {
-        return "The request URI is not valid. The segment '$postPostLinkSegment' is not valid. Since the uri contains the \$links segment, there must be only one segment specified after that.";
+        return 'The request URI is not valid. The segment \''.$postPostLinkSegment.'\' is not valid. Since the'
+               .' uri contains the $links segment, there must be only one segment specified after that.';
     }
 
     /**
@@ -55,7 +59,9 @@ trait segmentParser
      */
     public static function segmentParserOnlyValueSegmentAllowedAfterPrimitivePropertySegment($segment, $primitivePropertySegment)
     {
-        return "The segment '$segment' in the request URI is not valid. Since the segment '$primitivePropertySegment' refers to a primitive type property, the only supported value from the next segment is '\$value'.";
+        return 'The segment \''.$segment.'\' in the request URI is not valid. Since the segment \''
+               .$primitivePropertySegment.'\' refers to a primitive type property, the only supported value from'
+               .' the next segment is \'$value\'.';
     }
 
     /**
@@ -67,7 +73,9 @@ trait segmentParser
      */
     public static function segmentParserCannotQueryCollection($collectionSegment)
     {
-        return "The request URI is not valid. Since the segment '$collectionSegment' refers to a collection, this must be the last segment in the request URI. All intermediate segments must refer to a single resource.";
+        return 'The request URI is not valid. Since the segment \''.$collectionSegment.'\' refers to a'
+               .' collection, this must be the last segment in the request URI. All intermediate segments must'
+               .' refer to a single resource.';
     }
 
     /**
@@ -79,7 +87,8 @@ trait segmentParser
      */
     public static function segmentParserCountCannotFollowSingleton($segment)
     {
-        return "The request URI is not valid, since the segment '$segment' refers to a singleton, and the segment '\$count' can only follow a resource collection.";
+        return 'The request URI is not valid, since the segment \''.$segment.'\' refers to a singleton,'
+               .' and the segment \'$count\' can only follow a resource collection.';
     }
 
     /**
@@ -92,7 +101,8 @@ trait segmentParser
      */
     public static function segmentParserLinkSegmentMustBeFollowedByEntitySegment($segment)
     {
-        return "The request URI is not valid. The segment '$segment' must refer to a navigation property since the previous segment identifier is '\$links'.";
+        return 'The request URI is not valid. The segment \''.$segment.'\' must refer to a navigation property'
+               .' since the previous segment identifier is \'$links\'.';
     }
 
     /**
@@ -102,7 +112,8 @@ trait segmentParser
      */
     public static function segmentParserMissingSegmentAfterLink()
     {
-        return "The request URI is not valid. There must a segment specified after the '\$links' segment and the segment must refer to a entity resource.";
+        return 'The request URI is not valid. There must a segment specified after the \'$links\' segment and'
+               .' the segment must refer to a entity resource.';
     }
 
     /**
@@ -115,7 +126,8 @@ trait segmentParser
      */
     public static function segmentParserSegmentNotAllowedOnRoot($segment)
     {
-        return "The request URI is not valid, the segment '$segment' cannot be applied to the root of the service";
+        return 'The request URI is not valid, the segment \''.$segment.'\' cannot be applied to the root of the'
+               .' service';
     }
 
     /**
@@ -125,7 +137,7 @@ trait segmentParser
      */
     public static function segmentParserInconsistentTargetKindState()
     {
-        return 'Paring of segments failed for inconsistent target kind state, contact provider';
+        return 'Parsing of segments failed for inconsistent target kind state, contact provider';
     }
 
     /**
@@ -138,7 +150,7 @@ trait segmentParser
      */
     public static function segmentParserUnExpectedPropertyKind($expectedKind)
     {
-        return "Paring of segments failed expecting $expectedKind, contact provider";
+        return 'Parsing of segments failed expecting '.$expectedKind.', contact provider';
     }
 
     /**
@@ -150,6 +162,7 @@ trait segmentParser
      */
     public static function segmentParserCountCannotBeApplied($segment)
     {
-        return "The request URI is not valid, \$count cannot be applied to the segment '$segment' since \$count can only follow a resource segment.";
+        return 'The request URI is not valid, $count cannot be applied to the segment \''.$segment.'\' since '
+               .'$count can only follow a resource segment.';
     }
 }

--- a/src/POData/Common/Messages/skipTokenInfo.php
+++ b/src/POData/Common/Messages/skipTokenInfo.php
@@ -18,7 +18,8 @@ trait skipTokenInfo
      */
     public static function skipTokenInfoBothOrderByPathAndOrderByValuesShouldBeSetOrNotSet($orderByPathsVarName, $orderByValuesVarName)
     {
-        return "Either both the arguments $orderByPathsVarName and $orderByValuesVarName should be null or not-null";
+        return 'Either both the arguments '.$orderByPathsVarName.' and '.$orderByValuesVarName.' should be'
+               .' null or not-null';
     }
 
     /**
@@ -31,7 +32,7 @@ trait skipTokenInfo
      */
     public static function internalSkipTokenInfoFailedToAccessOrInitializeProperty($propertyName)
     {
-        return "internalSkipTokenInfo failed to access or initialize the property $propertyName";
+        return 'internalSkipTokenInfo failed to access or initialize the property '.$propertyName;
     }
 
     /**
@@ -44,6 +45,6 @@ trait skipTokenInfo
      */
     public static function internalSkipTokenInfoBinarySearchRequireArray($argumentName)
     {
-        return "The argument '$argumentName' should be an array to perfrom binary search";
+        return 'The argument \''.$argumentName.'\' should be an array to perfrom binary search';
     }
 }

--- a/src/POData/Common/Messages/skipTokenParser.php
+++ b/src/POData/Common/Messages/skipTokenParser.php
@@ -14,7 +14,7 @@ trait skipTokenParser
      */
     public static function skipTokenParserSyntaxError($skipToken)
     {
-        return "Bad Request - Error in the syntax of skiptoken '$skipToken'";
+        return 'Bad Request - Error in the syntax of skiptoken \''.$skipToken.'\'';
     }
 
     /**
@@ -40,7 +40,8 @@ trait skipTokenParser
      */
     public static function skipTokenParserSkipTokenNotMatchingOrdering($skipTokenValuesCount, $skipToken, $expectedCount)
     {
-        return "The number of keys '$skipTokenValuesCount' in skip token with value '$skipToken' did not match the number of ordering constraints '$expectedCount' for the resource type.";
+        return 'The number of keys \''.$skipTokenValuesCount.'\' in skip token with value \''.$skipToken
+               .'\' did not match the number of ordering constraints \''.$expectedCount.'\' for the resource type.';
     }
 
     /**
@@ -53,7 +54,7 @@ trait skipTokenParser
      */
     public static function skipTokenParserNullNotAllowedForKeys($skipToken)
     {
-        return "The skiptoken value $skipToken contain null value for key";
+        return 'The skiptoken value '.$skipToken.' contain null value for key';
     }
 
     /**
@@ -71,6 +72,8 @@ trait skipTokenParser
      */
     public static function skipTokenParserInCompatibleTypeAtPosition($skipToken, $expectedTypeName, $position, $typeProvidedInSkipTokenName)
     {
-        return "The skiptoken value '$skipToken' contain a value of type '$typeProvidedInSkipTokenName' at position $position which is not compatible with the type '$expectedTypeName' of corresponding orderby constraint.";
+        return 'The skiptoken value \''.$skipToken.'\' contains a value of type \''.$typeProvidedInSkipTokenName
+               .'\' at position '.$position.' which is not compatible with the type \''.$expectedTypeName
+               .'\' of corresponding orderby constraint.';
     }
 }

--- a/src/POData/Common/Messages/streamProviderWrapper.php
+++ b/src/POData/Common/Messages/streamProviderWrapper.php
@@ -51,7 +51,8 @@ trait streamProviderWrapper
      */
     public static function streamProviderWrapperMustImplementIStreamProviderToSupportStreaming()
     {
-        return 'To support streaming, the data service must implement IService::getStreamProviderX() to return an implementation of IStreamProvider or IStreamProvider2';
+        return 'To support streaming, the data service must implement IService::getStreamProviderX() to return'
+               .' an implementation of IStreamProvider or IStreamProvider2';
     }
 
     /**
@@ -61,17 +62,20 @@ trait streamProviderWrapper
      */
     public static function streamProviderWrapperMaxProtocolVersionMustBeV3OrAboveToSupportNamedStreams()
     {
-        return 'To support named streams, the MaxProtocolVersion of the data service must be set to ProtocolVersion.V3 or above.';
+        return 'To support named streams, the MaxProtocolVersion of the data service must be set to'
+               .' ProtocolVersion.V3 or above.';
     }
 
     /**
-     * Message to show error when data service does not provide implementation of IDDSP2 for which named stream is defined.
+     * Message to show error when data service does not provide implementation of IDDSP2 for which named stream is
+     * defined.
      *
      * @return string The message
      */
     public static function streamProviderWrapperMustImplementStreamProvider2ToSupportNamedStreams()
     {
-        return 'To support named streams, the data service must implement IServiceProvider.GetService() to return an implementation of IStreamProvider2 or the data source must implement IStreamProvider2.';
+        return 'To support named streams, the data service must implement IServiceProvider.GetService() to'
+               .' return an implementation of IStreamProvider2 or the data source must implement IStreamProvider2.';
     }
 
     /**
@@ -83,7 +87,7 @@ trait streamProviderWrapper
      */
     public static function streamProviderWrapperMustNotSetContentTypeAndEtag($methodName)
     {
-        return "The method $methodName must not set the HTTP response headers 'Content-Type' and 'ETag'";
+        return 'The method '.$methodName.' must not set the HTTP response headers \'Content-Type\' and \'ETag\'';
     }
 
     /**

--- a/src/POData/Common/Messages/uriProcessor.php
+++ b/src/POData/Common/Messages/uriProcessor.php
@@ -13,7 +13,7 @@ trait uriProcessor
      */
     public static function uriProcessorResourceNotFound($segment)
     {
-        return "Resource not found for the segment '$segment'.";
+        return 'Resource not found for the segment \''.$segment.'\'.';
     }
 
     /**
@@ -38,6 +38,6 @@ trait uriProcessor
      */
     public static function uriProcessorRequestUriDoesNotHaveTheRightBaseUri($requestUri, $serviceUri)
     {
-        return "The URI '$requestUri' is not valid since it is not based on '$serviceUri'";
+        return 'The URI \''.$requestUri.'\' is not valid since it is not based on \''.$serviceUri.'\'';
     }
 }

--- a/src/POData/OperationContext/ServiceHost.php
+++ b/src/POData/OperationContext/ServiceHost.php
@@ -519,7 +519,7 @@ class ServiceHost
             $this->getOperationContext()->outgoingResponse()->setContentLength($value);
         } else {
             throw ODataException::notAcceptableError(
-                "ContentLength:$value is invalid"
+                'ContentLength:'.$value.' is invalid'
             );
         }
     }
@@ -610,7 +610,7 @@ class ServiceHost
     /**
      * Get the response headers.
      *
-     * @return Array
+     * @return array
      */
     public function &getResponseHeaders()
     {

--- a/src/POData/Providers/Expression/MySQLExpressionProvider.php
+++ b/src/POData/Providers/Expression/MySQLExpressionProvider.php
@@ -249,47 +249,48 @@ class MySQLExpressionProvider implements IExpressionProvider
     {
         switch ($functionDescription->name) {
             case ODataConstants::STRFUN_COMPARE:
-                return "STRCMP($params[0], $params[1])";
+                return 'STRCMP('.$params[0].', '.$params[1].')';
 
             case ODataConstants::STRFUN_ENDSWITH:
-                return "(STRCMP($params[1],RIGHT($params[0],LENGTH($params[1]))) = 0)";
+                return '(STRCMP('.$params[1].',RIGHT('.$params[0].',LENGTH('.$params[1].'))) = 0)';
 
             case ODataConstants::STRFUN_INDEXOF:
-                return "INSTR($params[0], $params[1]) - 1";
+                return 'INSTR('.$params[0].', '.$params[1].') - 1';
 
             case ODataConstants::STRFUN_REPLACE:
-                return "REPLACE($params[0],$params[1],$params[2])";
+                return 'REPLACE('.$params[0].','.$params[1].','.$params[2].')';
 
             case ODataConstants::STRFUN_STARTSWITH:
-                return "(STRCMP($params[1],LEFT($params[0],LENGTH($params[1]))) = 0)";
+                return '(STRCMP('.$params[1].',LEFT('.$params[0].',LENGTH('.$params[1].'))) = 0)';
 
             case ODataConstants::STRFUN_TOLOWER:
-                return "LOWER($params[0])";
+                return 'LOWER('.$params[0].')';
 
             case ODataConstants::STRFUN_TOUPPER:
-                return "UPPER($params[0])";
+                return 'UPPER('.$params[0].')';
 
             case ODataConstants::STRFUN_TRIM:
-                return "TRIM($params[0])";
+                return 'TRIM('.$params[0].')';
 
             case ODataConstants::STRFUN_SUBSTRING:
                 return count($params) == 3 ?
-                    "SUBSTRING($params[0], $params[1] + 1, $params[2])" : "SUBSTRING($params[0], $params[1] + 1)";
+                    'SUBSTRING('.$params[0].', '.$params[1].' + 1, '.$params[2].')'
+                    : 'SUBSTRING('.$params[0].', '.$params[1].' + 1)';
 
             case ODataConstants::STRFUN_SUBSTRINGOF:
-                return "(LOCATE($params[0], $params[1]) > 0)";
+                return '(LOCATE('.$params[0].', '.$params[1].') > 0)';
 
             case ODataConstants::STRFUN_CONCAT:
-                return "CONCAT($params[0],$params[1])";
+                return 'CONCAT('.$params[0].','.$params[1].')';
 
             case ODataConstants::STRFUN_LENGTH:
-                return "LENGTH($params[0])";
+                return 'LENGTH('.$params[0].')';
 
             case ODataConstants::GUIDFUN_EQUAL:
-                return "STRCMP($params[0], $params[1])";
+                return 'STRCMP('.$params[0].', '.$params[1].')';
 
             case ODataConstants::DATETIME_COMPARE:
-                return "DATETIMECMP($params[0]; $params[1])";
+                return 'DATETIMECMP('.$params[0].'; '.$params[1].')';
 
             case ODataConstants::DATETIME_YEAR:
                 return 'EXTRACT(YEAR from ' . $params[0] . ')';
@@ -310,19 +311,19 @@ class MySQLExpressionProvider implements IExpressionProvider
                 return 'EXTRACT(SECOND from ' . $params[0] . ')';
 
             case ODataConstants::MATHFUN_ROUND:
-                return "ROUND($params[0])";
+                return 'ROUND('.$params[0].')';
 
             case ODataConstants::MATHFUN_CEILING:
-                return "CEIL($params[0])";
+                return 'CEIL('.$params[0].')';
 
             case ODataConstants::MATHFUN_FLOOR:
-                return "FLOOR($params[0])";
+                return 'FLOOR('.$params[0].')';
 
             case ODataConstants::BINFUL_EQUAL:
-                return "($params[0] = $params[1])";
+                return '('.$params[0].' = '.$params[1].')';
 
             case 'is_null':
-                return "is_null($params[0])";
+                return 'is_null('.$params[0].')';
 
             default:
                 throw new \InvalidArgumentException('onFunctionCallExpression');

--- a/src/POData/Providers/Expression/PHPExpressionProvider.php
+++ b/src/POData/Providers/Expression/PHPExpressionProvider.php
@@ -258,80 +258,81 @@ class PHPExpressionProvider implements IExpressionProvider
     {
         switch ($functionDescription->name) {
             case ODataConstants::STRFUN_COMPARE:
-                return "strcmp($params[0], $params[1])";
+                return 'strcmp('.$params[0].', '.$params[1].')';
 
             case ODataConstants::STRFUN_ENDSWITH:
-                return "(strcmp(substr($params[0], strlen($params[0]) - strlen($params[1])), $params[1]) === 0)";
+                return '(strcmp(substr('.$params[0].', strlen('.$params[0].') - strlen('.$params[1].')), '
+                       .$params[1].') === 0)';
 
             case ODataConstants::STRFUN_INDEXOF:
-                return "strpos($params[0], $params[1])";
+                return 'strpos('.$params[0].', '.$params[1].')';
 
             case ODataConstants::STRFUN_REPLACE:
-                return "str_replace($params[1], $params[2], $params[0])";
+                return 'str_replace('.$params[1].', '.$params[2].', '.$params[0].')';
 
             case ODataConstants::STRFUN_STARTSWITH:
-                return "(strpos($params[0], $params[1]) === 0)";
+                return '(strpos('.$params[0].', '.$params[1].') === 0)';
 
             case ODataConstants::STRFUN_TOLOWER:
-                return "strtolower($params[0])";
+                return 'strtolower('.$params[0].')';
 
             case ODataConstants::STRFUN_TOUPPER:
-                return "strtoupper($params[0])";
+                return 'strtoupper('.$params[0].')';
 
             case ODataConstants::STRFUN_TRIM:
-                return "trim($params[0])";
+                return 'trim('.$params[0].')';
 
             case ODataConstants::STRFUN_SUBSTRING:
                 return count($params) == 3 ?
-                    "substr($params[0], $params[1], $params[2])" : "substr($params[0], $params[1])";
+                    'substr('.$params[0].', '.$params[1].', '.$params[2].')' : 'substr('.$params[0].', '.$params[1].')';
 
             case ODataConstants::STRFUN_SUBSTRINGOF:
-                return "(strpos($params[1], $params[0]) !== false)";
+                return '(strpos('.$params[1].', '.$params[0].') !== false)';
 
             case ODataConstants::STRFUN_CONCAT:
                 return $params[0] . ' . ' . $params[1];
 
             case ODataConstants::STRFUN_LENGTH:
-                return "strlen($params[0])";
+                return 'strlen('.$params[0].')';
 
             case ODataConstants::GUIDFUN_EQUAL:
-                return self::TYPE_NAMESPACE . "Guid::guidEqual($params[0], $params[1])";
+                return self::TYPE_NAMESPACE . 'Guid::guidEqual('.$params[0].', '.$params[1].')';
 
             case ODataConstants::DATETIME_COMPARE:
-                return self::TYPE_NAMESPACE . "DateTime::dateTimeCmp($params[0], $params[1])";
+                return self::TYPE_NAMESPACE . 'DateTime::dateTimeCmp('.$params[0].', '.$params[1].')';
 
             case ODataConstants::DATETIME_YEAR:
-                return self::TYPE_NAMESPACE . "DateTime::year($params[0])";
+                return self::TYPE_NAMESPACE . 'DateTime::year('.$params[0].')';
 
             case ODataConstants::DATETIME_MONTH:
-                return self::TYPE_NAMESPACE . "DateTime::month($params[0])";
+                return self::TYPE_NAMESPACE . 'DateTime::month('.$params[0].')';
 
             case ODataConstants::DATETIME_DAY:
-                return self::TYPE_NAMESPACE . "DateTime::day($params[0])";
+                return self::TYPE_NAMESPACE . 'DateTime::day('.$params[0].')';
 
             case ODataConstants::DATETIME_HOUR:
-                return self::TYPE_NAMESPACE . "DateTime::hour($params[0])";
+                return self::TYPE_NAMESPACE . 'DateTime::hour('.$params[0].')';
 
             case ODataConstants::DATETIME_MINUTE:
-                return self::TYPE_NAMESPACE . "DateTime::minute($params[0])";
+                return self::TYPE_NAMESPACE . 'DateTime::minute('.$params[0].')';
 
             case ODataConstants::DATETIME_SECOND:
-                return self::TYPE_NAMESPACE . "DateTime::second($params[0])";
+                return self::TYPE_NAMESPACE . 'DateTime::second('.$params[0].')';
 
             case ODataConstants::MATHFUN_ROUND:
-                return "round($params[0])";
+                return 'round('.$params[0].')';
 
             case ODataConstants::MATHFUN_CEILING:
-                return "ceil($params[0])";
+                return 'ceil('.$params[0].')';
 
             case ODataConstants::MATHFUN_FLOOR:
-                return "floor($params[0])";
+                return 'floor('.$params[0].')';
 
             case ODataConstants::BINFUL_EQUAL:
-                return self::TYPE_NAMESPACE . "Binary::binaryEqual($params[0], $params[1])";
+                return self::TYPE_NAMESPACE . 'Binary::binaryEqual('.$params[0].', '.$params[1].')';
 
             case 'is_null':
-                return "is_null($params[0])";
+                return 'is_null('.$params[0].')';
 
             default:
                 throw new \InvalidArgumentException('onFunctionCallExpression');

--- a/tests/UnitTests/POData/BaseServiceNewTest.php
+++ b/tests/UnitTests/POData/BaseServiceNewTest.php
@@ -836,7 +836,7 @@ class BaseServiceNewTest extends TestCase
 
         $expected = 'If-Match or If-None-Match HTTP headers cannot be specified since the'
                     .' URI \'https://www.example.org/odata.svc\' refers to a collection of resources or has'
-                    .' a $count or $link segment or has a $expand as one of the query parameters.';
+                    .' a $count or $link segment or has an $expand as one of the query parameters.';
         $actual = null;
 
         try {

--- a/tests/UnitTests/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/SelectTest.php
+++ b/tests/UnitTests/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/SelectTest.php
@@ -130,8 +130,8 @@ class SelectTest extends TestCase
         //We applied '*' on root, so flag for selection of all immediate properties must me true
         $this->assertTrue($projectionTreeRoot->canSelectAllImmediateProperties());
         $this->assertTrue($projectionTreeRoot->canSelectAllProperties());
-        //Even though we explicity selected 'CustomerID', 'CustomerName' and link to 'Orders'
-        //these children will be removed since '*' implcilty select all properties
+        //Even though we explicitly selected 'CustomerID', 'CustomerName' and link to 'Orders'
+        //these children will be removed since '*' implicitly select all properties
         $this->assertEquals(count($projectionTreeRoot->getChildNodes()), 0);
     }
 
@@ -163,23 +163,23 @@ class SelectTest extends TestCase
 
         try {
             //Try to traverse 'Orders' on select without expanding
-                $projectionTreeRoot = ExpandProjectionParser::parseExpandAndSelectClause(
-                    $customersResourceSetWrapper,
-                    $customerResourceType,
-                    null,
-                    null,
-                    null,
-                    null, // $expand
-                    'Orders/OrderID', //$select
-                    $providersWrapper
-                );
-                $this->fail('An expected ODataException for traversal on select without expansion has not been thrown');
+            $projectionTreeRoot = ExpandProjectionParser::parseExpandAndSelectClause(
+                $customersResourceSetWrapper,
+                $customerResourceType,
+                null,
+                null,
+                null,
+                null, // $expand
+                'Orders/OrderID', //$select
+                $providersWrapper
+            );
+            $this->fail('An expected ODataException for traversal on select without expansion has not been thrown');
         } catch (ODataException $odataException) {
-                $this->assertStringStartsWith(
-                    'Only navigation properties specified in expand option can be traversed in select option.  '
-                    .'In order to traverse',
-                    $odataException->getMessage()
-                );
+            $this->assertStringStartsWith(
+                'Only navigation properties specified in expand option can be traversed in select option.  '
+                .'In order to traverse',
+                $odataException->getMessage()
+            );
         }
     }
 

--- a/tests/UnitTests/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/SelectTest.php
+++ b/tests/UnitTests/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/SelectTest.php
@@ -173,9 +173,13 @@ class SelectTest extends TestCase
                     'Orders/OrderID', //$select
                     $providersWrapper
                 );
-            $this->fail('An expected ODataException for traversal on select without expansion has not been thrown');
+                $this->fail('An expected ODataException for traversal on select without expansion has not been thrown');
         } catch (ODataException $odataException) {
-            $this->assertStringStartsWith('Only navigation properties specified in expand option can be travered in select option,In order to treaverse', $odataException->getMessage());
+                $this->assertStringStartsWith(
+                    'Only navigation properties specified in expand option can be traversed in select option.  '
+                    .'In order to traverse',
+                    $odataException->getMessage()
+                );
         }
     }
 

--- a/tests/UnitTests/POData/UriProcessor/QueryProcessor/SkipTokenParser/SkipTokenParserTest.php
+++ b/tests/UnitTests/POData/UriProcessor/QueryProcessor/SkipTokenParser/SkipTokenParserTest.php
@@ -196,7 +196,7 @@ class SkipTokenParserTest extends TestCase
             $internalSkipTokenInfo = SkipTokenParser::parseSkipTokenClause($resourceType, $internalOrderByInfo, $skipToken);
             $this->fail('An expected ODataException for type mismatch (datetime and string) ');
         } catch (ODataException $odataException) {
-            $this->assertStringStartsWith('The skiptoken value \'datetime\'1996-07-12T03:58:58\', 22.00, 1234\' contain a value of type \'Edm.DateTime\' at position 0 which is not compatible with the type \'Edm.String\' of corresponding orderby constraint', $odataException->getMessage());
+            $this->assertStringStartsWith('The skiptoken value \'datetime\'1996-07-12T03:58:58\', 22.00, 1234\' contains a value of type \'Edm.DateTime\' at position 0 which is not compatible with the type \'Edm.String\' of corresponding orderby constraint', $odataException->getMessage());
         }
 
         //Price is Double, but in skiptoken uses true
@@ -207,7 +207,7 @@ class SkipTokenParserTest extends TestCase
             $internalSkipTokenInfo = SkipTokenParser::parseSkipTokenClause($resourceType, $internalOrderByInfo, $skipToken);
             $this->fail('An expected ODataException for type mismatch (boolean and double) ');
         } catch (ODataException $odataException) {
-            $this->assertStringStartsWith('The skiptoken value \'\'ANS\', true, 1234\' contain a value of type \'Edm.Boolean\' at position 1 which is not compatible with the type \'Edm.Double\' of corresponding orderby constraint', $odataException->getMessage());
+            $this->assertStringStartsWith('The skiptoken value \'\'ANS\', true, 1234\' contains a value of type \'Edm.Boolean\' at position 1 which is not compatible with the type \'Edm.Double\' of corresponding orderby constraint', $odataException->getMessage());
         }
 
         //null is allowed in skiptoken and compactable with all types

--- a/tests/UnitTests/POData/UriProcessor/ResourcePathProcessor/SegmentParser/KeyDescriptorTest.php
+++ b/tests/UnitTests/POData/UriProcessor/ResourcePathProcessor/SegmentParser/KeyDescriptorTest.php
@@ -194,7 +194,7 @@ class KeyDescriptorTest extends TestCase
             $keyDescriptor->validate('Order_Details(ProductID=11, OrderID1=2546)', $orderDetailsResourceType);
             $this->fail('An expected ODataException for missing of keys in the predicate has not been thrown');
         } catch (ODataException $exception) {
-            $this->assertStringEndsWith('The key predicate expect the keys \'ProductID, OrderID\'', $exception->getMessage());
+            $this->assertStringEndsWith('The key predicate expects the keys \'ProductID, OrderID\'', $exception->getMessage());
         }
 
         //test for key type


### PR DESCRIPTION
Clean up ancestral coding style that interpolates variables directly into "-terminated strings instead of concatenating them onto string literals