### PR TITLE
Model deserialiser case insensitivity

### DIFF
--- a/src/POData/ObjectModel/ModelDeserialiser.php
+++ b/src/POData/ObjectModel/ModelDeserialiser.php
@@ -51,6 +51,7 @@ class ModelDeserialiser
                 $propName = $prop->getName();
                 if (!in_array($propName, $keyNames) && !($prop->getResourceType() instanceof ResourceEntityType)) {
                     $nonRelProp[] = $propName;
+                    $nonRelProp[] = strtolower($propName);
                 }
             }
             self::$nonKeyPropertiesCache[$actualType] = $nonRelProp;
@@ -61,7 +62,7 @@ class ModelDeserialiser
         // assemble data array
         $data = [];
         foreach ($payload->propertyContent->properties as $propName => $propSpec) {
-            if (in_array($propName, $nonRelProp)) {
+            if (in_array($propName, $nonRelProp) || in_array(strtolower($propName), $nonRelProp)) {
                 $rawVal = $propSpec->value;
                 $data[$propName] = trim($rawVal);
             }

--- a/src/POData/ObjectModel/ModelDeserialiser.php
+++ b/src/POData/ObjectModel/ModelDeserialiser.php
@@ -63,7 +63,7 @@ class ModelDeserialiser
         foreach ($payload->propertyContent->properties as $propName => $propSpec) {
             if (array_key_exists($propName, $nonRelProp)) {
                 $rawVal = $propSpec->value;
-                $data[$propName] = $rawVal;
+                $data[$propName] = trim($rawVal);
             }
         }
 

--- a/src/POData/ObjectModel/ModelDeserialiser.php
+++ b/src/POData/ObjectModel/ModelDeserialiser.php
@@ -50,7 +50,7 @@ class ModelDeserialiser
             foreach ($rawProp as $prop) {
                 $propName = $prop->getName();
                 if (!in_array($propName, $keyNames) && !($prop->getResourceType() instanceof ResourceEntityType)) {
-                    $nonRelProp[$propName] = $prop;
+                    $nonRelProp[] = $propName;
                 }
             }
             self::$nonKeyPropertiesCache[$actualType] = $nonRelProp;
@@ -61,7 +61,7 @@ class ModelDeserialiser
         // assemble data array
         $data = [];
         foreach ($payload->propertyContent->properties as $propName => $propSpec) {
-            if (array_key_exists($propName, $nonRelProp)) {
+            if (in_array($propName, $nonRelProp)) {
                 $rawVal = $propSpec->value;
                 $data[$propName] = trim($rawVal);
             }

--- a/tests/UnitTests/POData/ObjectModel/Serialisers/ModelDeserialiserTest.php
+++ b/tests/UnitTests/POData/ObjectModel/Serialisers/ModelDeserialiserTest.php
@@ -85,10 +85,10 @@ class ModelDeserialiserTest extends SerialiserTestBase
         $propContent->properties['CustomerGuid']->value = '123e4567-e89b-12d3-a456-426655440000';
         $propContent->properties['CustomerName']->name = 'CustomerName';
         $propContent->properties['CustomerName']->typeName = 'Edm.String';
-        $propContent->properties['CustomerName']->value = 'MakeItPhunkee';
+        $propContent->properties['CustomerName']->value = ' MakeItPhunkee ';
         $propContent->properties['Country']->name = 'Country';
         $propContent->properties['Country']->typeName = 'Edm.String';
-        $propContent->properties['Country']->value = 'Oop North';
+        $propContent->properties['Country']->value = ' Oop North ';
         $propContent->properties['Rating']->name = 'Rating';
         $propContent->properties['Rating']->typeName = 'Edm.Int32';
         $propContent->properties['Photo']->name = 'Photo';

--- a/tests/UnitTests/POData/ObjectModel/Serialisers/ModelDeserialiserTest.php
+++ b/tests/UnitTests/POData/ObjectModel/Serialisers/ModelDeserialiserTest.php
@@ -75,7 +75,7 @@ class ModelDeserialiserTest extends SerialiserTestBase
 
         $propContent = new ODataPropertyContent();
         $propContent->properties = ['CustomerID' => new ODataProperty(), 'CustomerGuid' => new ODataProperty(),
-            'CustomerName' => new ODataProperty(), 'Country' => new ODataProperty(), 'Rating' => new ODataProperty(),
+            'CustomerName' => new ODataProperty(), 'country' => new ODataProperty(), 'Rating' => new ODataProperty(),
             'Photo' => new ODataProperty(), 'Address' => new ODataProperty()];
         $propContent->properties['CustomerID']->name = 'CustomerID';
         $propContent->properties['CustomerID']->typeName = 'Edm.String';
@@ -86,9 +86,9 @@ class ModelDeserialiserTest extends SerialiserTestBase
         $propContent->properties['CustomerName']->name = 'CustomerName';
         $propContent->properties['CustomerName']->typeName = 'Edm.String';
         $propContent->properties['CustomerName']->value = ' MakeItPhunkee ';
-        $propContent->properties['Country']->name = 'Country';
-        $propContent->properties['Country']->typeName = 'Edm.String';
-        $propContent->properties['Country']->value = ' Oop North ';
+        $propContent->properties['country']->name = 'country';
+        $propContent->properties['country']->typeName = 'Edm.String';
+        $propContent->properties['country']->value = ' Oop North ';
         $propContent->properties['Rating']->name = 'Rating';
         $propContent->properties['Rating']->typeName = 'Edm.Int32';
         $propContent->properties['Photo']->name = 'Photo';
@@ -115,7 +115,7 @@ class ModelDeserialiserTest extends SerialiserTestBase
         $cereal = new ModelDeserialiser();
         $cereal->reset();
 
-        $expected = ['CustomerName' => 'MakeItPhunkee', 'Country' => 'Oop North', 'Rating' => null, 'Photo' => null,
+        $expected = ['CustomerName' => 'MakeItPhunkee', 'country' => 'Oop North', 'Rating' => null, 'Photo' => null,
             'Address' => null];
 
         $actual = $cereal->bulkDeserialise($type, $objectResult);


### PR DESCRIPTION
Trim whitespace from property values, as XMLArray used to do.
Store resource property names in ModelDeserialiser - no need to store whole shebang.
Make model deserialisation robust to case mismatches between metadata property names and what actual object has.