### PR TITLE
Add concrete type handling

### DIFF
--- a/src/POData/ObjectModel/ODataEntry.php
+++ b/src/POData/ObjectModel/ODataEntry.php
@@ -276,11 +276,11 @@ class ODataEntry
     public function isOk(&$msg = null)
     {
         if (!$this->propertyContent instanceof ODataPropertyContent) {
-            $msg = 'Property content must be instanceof ODataPropertyContent';
+            $msg = 'Property content must be instanceof ODataPropertyContent.';
             return false;
         }
         if (0 === count($this->propertyContent->properties)) {
-            $msg = 'Must have at least one property present';
+            $msg = 'Must have at least one property present.';
             return false;
         }
 

--- a/src/POData/OperationContext/Web/IncomingRequest.php
+++ b/src/POData/OperationContext/Web/IncomingRequest.php
@@ -58,7 +58,6 @@ class IncomingRequest implements IHTTPRequest
         $this->queryOptions = [];
         $this->queryOptionsCount = [];
         $this->headers = [];
-        $this->getHeaders();
     }
 
     /**

--- a/src/POData/Providers/Metadata/ResourceAssociationSet.php
+++ b/src/POData/Providers/Metadata/ResourceAssociationSet.php
@@ -173,4 +173,9 @@ class ResourceAssociationSet
     {
         return $sourceType->getName() . '_' . $linkName . '_' . $targetResourceSet->getResourceType()->getName();
     }
+
+    public static function keyNameFromTypeAndProperty(ResourceEntityType $sourceType, ResourceProperty $property)
+    {
+        return $sourceType->getName() . '_' . $property->getName() . '_' . $property->getResourceType()->getName();
+    }
 }

--- a/src/POData/Providers/Metadata/ResourceAssociationSetEnd.php
+++ b/src/POData/Providers/Metadata/ResourceAssociationSetEnd.php
@@ -24,6 +24,14 @@ class ResourceAssociationSetEnd
     private $resourceType;
 
     /**
+     * Concrete resource type for the association end.  Should only be set if $resourceType is abstract.
+     * Is assumed to be a derived type of $resourceType if set.
+     *
+     * @var ResourceEntityType
+     */
+    private $concreteType;
+
+    /**
      * Resource property for the association end.
      *
      * @var ResourceProperty
@@ -46,7 +54,8 @@ class ResourceAssociationSetEnd
     public function __construct(
         ResourceSet $resourceSet,
         ResourceEntityType $resourceType,
-        ResourceProperty $resourceProperty = null
+        ResourceProperty $resourceProperty = null,
+        ResourceEntityType $concreteType = null
     ) {
         if (null !== $resourceProperty
             && (null === $resourceType->resolveProperty($resourceProperty->getName())
@@ -71,10 +80,27 @@ class ResourceAssociationSetEnd
                 )
             );
         }
+        if (null !== $concreteType) {
+            if (!$resourceType->isAbstract()) {
+                $msg = 'Base type must be abstract if concrete type supplied';
+                throw new \InvalidArgumentException($msg);
+            }
+            if ($concreteType->isAbstract()) {
+                $msg = 'Concrete type must not be abstract if explicitly supplied';
+                throw new \InvalidArgumentException($msg);
+            }
+            if ($concreteType->getBaseType() != $resourceType) {
+                $msg = 'Concrete type must be a derived type of supplied base type';
+                throw new \InvalidArgumentException($msg);
+            }
+        } else {
+            $concreteType = $resourceType;
+        }
 
         $this->resourceSet = $resourceSet;
         $this->resourceType = $resourceType;
         $this->resourceProperty = $resourceProperty;
+        $this->concreteType = $concreteType;
     }
 
     /**
@@ -120,6 +146,16 @@ class ResourceAssociationSetEnd
     public function getResourceType()
     {
         return $this->resourceType;
+    }
+
+    /**
+     * Gets reference to concrete type.
+     *
+     * @return ResourceEntityType
+     */
+    public function getConcreteType()
+    {
+        return $this->concreteType;
     }
 
     /**

--- a/src/POData/Providers/Metadata/ResourceAssociationSetEnd.php
+++ b/src/POData/Providers/Metadata/ResourceAssociationSetEnd.php
@@ -85,14 +85,15 @@ class ResourceAssociationSetEnd
                 $msg = 'Concrete type must not be abstract if explicitly supplied';
                 throw new \InvalidArgumentException($msg);
             }
+            $concType = $concreteType;
         } else {
-            $concreteType = $resourceType;
+            $concType = $resourceType;
         }
 
         $this->resourceSet = $resourceSet;
         $this->resourceType = $resourceType;
         $this->resourceProperty = $resourceProperty;
-        $this->concreteType = $concreteType;
+        $this->concreteType = $concType;
     }
 
     /**

--- a/src/POData/Providers/Metadata/ResourceAssociationSetEnd.php
+++ b/src/POData/Providers/Metadata/ResourceAssociationSetEnd.php
@@ -81,16 +81,8 @@ class ResourceAssociationSetEnd
             );
         }
         if (null !== $concreteType) {
-            if (!$resourceType->isAbstract()) {
-                $msg = 'Base type must be abstract if concrete type supplied';
-                throw new \InvalidArgumentException($msg);
-            }
             if ($concreteType->isAbstract()) {
                 $msg = 'Concrete type must not be abstract if explicitly supplied';
-                throw new \InvalidArgumentException($msg);
-            }
-            if ($concreteType->getBaseType() != $resourceType) {
-                $msg = 'Concrete type must be a derived type of supplied base type';
                 throw new \InvalidArgumentException($msg);
             }
         } else {

--- a/src/POData/Providers/Metadata/SimpleMetadataProvider.php
+++ b/src/POData/Providers/Metadata/SimpleMetadataProvider.php
@@ -676,10 +676,9 @@ class SimpleMetadataProvider implements IMetadataProvider
             new ResourceAssociationSetEnd(
                 $sourceResourceSet,
                 $sourceResourceType,
-                $sourceResourceProperty,
-                $concreteType
+                $sourceResourceProperty
             ),
-            new ResourceAssociationSetEnd($targetResourceSet, $targetResourceType, null)
+            new ResourceAssociationSetEnd($targetResourceSet, $targetResourceType, null, $concreteType)
         );
         $mult = $resourceMult;
         $backMult = $many ? '*' : $backMultArray[$resourceMult];
@@ -827,6 +826,7 @@ class SimpleMetadataProvider implements IMetadataProvider
             $name,
             $targetResourceSet,
             '*',
+            null,
             $concreteType
         );
     }

--- a/src/POData/Providers/Metadata/SimpleMetadataProvider.php
+++ b/src/POData/Providers/Metadata/SimpleMetadataProvider.php
@@ -552,27 +552,30 @@ class SimpleMetadataProvider implements IMetadataProvider
     /**
      * To add a resource reference property.
      *
-     * @param ResourceEntityType $resourceType      The resource type to add the resource
-     *                                              reference property to
-     * @param string             $name              The name of the property to add
-     * @param ResourceSet        $targetResourceSet The resource set the resource reference
-     *                                              property points to
-     * @param mixed              $flip
-     * @param mixed              $many
+     * @param ResourceEntityType        $resourceType       The resource type to add the resource
+     *                                                      reference property to
+     * @param string                    $name               The name of the property to add
+     * @param ResourceSet               $targetResourceSet  The resource set the resource reference
+     *                                                      property points to
+     * @param mixed                     $flip
+     * @param mixed                     $many
+     * @param ResourceEntityType|null   $concreteType       Underlying concrete resource reference type, if set
      */
     public function addResourceReferenceProperty(
         ResourceEntityType $resourceType,
         $name,
         ResourceSet $targetResourceSet,
         $flip = false,
-        $many = false
+        $many = false,
+        ResourceEntityType $concreteType = null
     ) {
         $this->addReferencePropertyInternal(
             $resourceType,
             $name,
             $targetResourceSet,
             $flip ? '0..1' : '1',
-            $many
+            $many,
+            $concreteType
         );
     }
 
@@ -633,7 +636,8 @@ class SimpleMetadataProvider implements IMetadataProvider
         $name,
         ResourceSet $targetResourceSet,
         $resourceMult,
-        $many = false
+        $many = false,
+        ResourceEntityType $concreteType = null
     ) {
         $allowedMult = ['*', '1', '0..1'];
         $backMultArray = [ '*' => '*', '1' => '0..1', '0..1' => '1'];
@@ -669,7 +673,12 @@ class SimpleMetadataProvider implements IMetadataProvider
         //$setKey = $sourceResourceType->getName() . '_' . $name . '_' . $targetResourceType->getName();
         $set = new ResourceAssociationSet(
             $setKey,
-            new ResourceAssociationSetEnd($sourceResourceSet, $sourceResourceType, $sourceResourceProperty),
+            new ResourceAssociationSetEnd(
+                $sourceResourceSet,
+                $sourceResourceType,
+                $sourceResourceProperty,
+                $concreteType
+            ),
             new ResourceAssociationSetEnd($targetResourceSet, $targetResourceType, null)
         );
         $mult = $resourceMult;
@@ -800,19 +809,25 @@ class SimpleMetadataProvider implements IMetadataProvider
     /**
      * To add a resource set reference property.
      *
-     * @param ResourceEntityType $resourceType      The resource type to add the
-     *                                              resource reference set property to
-     * @param string             $name              The name of the property to add
-     * @param ResourceSet        $targetResourceSet The resource set the resource
-     *                                              reference set property points to
+     * @param ResourceEntityType        $resourceType       The resource type to add the
+     *                                                      resource reference set property to
+     * @param string                    $name               The name of the property to add
+     * @param ResourceSet               $targetResourceSet  The resource set the resource
+     *                                                      reference set property points to
+     * @param ResourceEntityType|null   $concreteType       Underlying concrete resource type, if set
      */
-    public function addResourceSetReferenceProperty(ResourceEntityType $resourceType, $name, $targetResourceSet)
-    {
+    public function addResourceSetReferenceProperty(
+        ResourceEntityType $resourceType,
+        $name,
+        $targetResourceSet,
+        ResourceEntityType $concreteType = null
+    ) {
         $this->addReferencePropertyInternal(
             $resourceType,
             $name,
             $targetResourceSet,
-            '*'
+            '*',
+            $concreteType
         );
     }
 

--- a/src/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/ExpandProjectionParser.php
+++ b/src/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/ExpandProjectionParser.php
@@ -408,4 +408,12 @@ class ExpandProjectionParser
 
         return $pathSegments;
     }
+
+    /**
+     * @return ProvidersWrapper
+     */
+    public function getProviderWrapper()
+    {
+        return $this->providerWrapper;
+    }
 }

--- a/src/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/ExpandProjectionParser.php
+++ b/src/POData/UriProcessor/QueryProcessor/ExpandProjectionParser/ExpandProjectionParser.php
@@ -6,6 +6,7 @@ use POData\Common\Messages;
 use POData\Common\ODataException;
 use POData\Providers\Metadata\ResourceAssociationSet;
 use POData\Providers\Metadata\ResourceEntityType;
+use POData\Providers\Metadata\ResourceProperty;
 use POData\Providers\Metadata\ResourcePropertyKind;
 use POData\Providers\Metadata\ResourceSet;
 use POData\Providers\Metadata\ResourceSetWrapper;
@@ -182,6 +183,7 @@ class ExpandProjectionParser
                 $resourceType = $currentNode->getResourceType();
                 assert($resourceType instanceof ResourceEntityType);
                 $resourceProperty = $resourceType->resolveProperty($expandSubPathSegment);
+                assert($resourceProperty instanceof ResourceProperty);
                 $keyType = ResourceAssociationSet::keyNameFromTypeAndProperty($resourceType, $resourceProperty);
                 $assoc = $this->getProviderWrapper()->getMetaProvider()->resolveAssociationSet($keyType);
                 $concreteType = isset($assoc) ? $assoc->getEnd2()->getConcreteType() : $resourceType;
@@ -230,9 +232,8 @@ class ExpandProjectionParser
                     $this->rootProjectionNode->setPagedExpandedResult(true);
                     $rt = $resourceSetWrapper->getResourceType();
                     $payloadType = $rt->isAbstract() ? $concreteType : $rt;
-                    //assert($rt != null)
+
                     $keys = array_keys($rt->getKeyProperties());
-                    //assert(!empty($keys))
                     $orderBy = null;
                     foreach ($keys as $key) {
                         $orderBy = $orderBy . $key . ', ';

--- a/tests/UnitTests/POData/ObjectModel/ODataEntryTest.php
+++ b/tests/UnitTests/POData/ObjectModel/ODataEntryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace UnitTests\POData\ObjectModel;
+
+use POData\ObjectModel\ODataEntry;
+use POData\ObjectModel\ODataPropertyContent;
+use UnitTests\POData\TestCase;
+
+class ODataEntryTest extends TestCase
+{
+    public function testOkNoContent()
+    {
+        $foo = new ODataEntry();
+        $expected = 'Property content must be instanceof ODataPropertyContent.';
+
+        $actual = null;
+        $foo->isOK($actual);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testOkEmptyContent()
+    {
+        $foo = new ODataEntry();
+        $foo->propertyContent = new ODataPropertyContent();
+        $expected = 'Must have at least one property present.';
+
+        $actual = null;
+        $foo->isOK($actual);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/UnitTests/POData/OperationContext/Web/IncomingRequestTest.php
+++ b/tests/UnitTests/POData/OperationContext/Web/IncomingRequestTest.php
@@ -97,4 +97,13 @@ class IncomingRequestTest extends TestCase
         $this->assertEquals($expected, $actual);
         $this->assertNull($incoming->getRequestHeader('REQUEST_TYPE'));
     }
+
+    public function testGetEmptyQueryStringParameters()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $incoming = new IncomingRequest();
+        $result = $incoming->getQueryParameters();
+        $this->assertTrue(is_array($result));
+        $this->assertEquals(1, count($result));
+    }
 }

--- a/tests/UnitTests/POData/Providers/Metadata/ResourceAssociationSetEndTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/ResourceAssociationSetEndTest.php
@@ -116,4 +116,30 @@ class ResourceAssociationSetEndTest extends TestCase
         $actual = $result->getName();
         $this->assertEquals($expected, $actual);
     }
+
+    public function testGetConcreteTypeWhenExplicitlySupplied()
+    {
+        $property = m::mock(ResourceProperty::class);
+        $property->shouldReceive('getName')->andReturn('property');
+        $property->shouldReceive('getKind')->andReturn(ResourcePropertyKind::RESOURCE_REFERENCE);
+        $expected = 'TypeWithNoName';
+
+        $concrete = m::mock(ResourceEntityType::class);
+        $concrete->shouldReceive('isAbstract')->andReturn(false);
+        $concrete->shouldReceive('getName')->andReturn($expected);
+
+        $base = m::mock(ResourceEntityType::class);
+        $base->shouldReceive('isAbstract')->andReturn(false);
+        $base->shouldReceive('resolveProperty')->andReturn($property);
+        $base->shouldReceive('isAssignableFrom')->andReturn(true);
+        $base->shouldReceive('getName')->andReturn('foo');
+
+        $set = m::mock(ResourceSet::class);
+        $set->shouldReceive('getResourceType')->andReturn($base);
+
+        $foo = new ResourceAssociationSetEnd($set, $base, $property, $concrete);
+        $result = $foo->getConcreteType();
+        $actual = $result->getName();
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/UnitTests/POData/Providers/Metadata/ResourceAssociationSetEndTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/ResourceAssociationSetEndTest.php
@@ -95,61 +95,6 @@ class ResourceAssociationSetEndTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testResourceAssociationSetEndWithConcreteBaseTypeAndConcreteType()
-    {
-        $property = m::mock(ResourceProperty::class);
-        $property->shouldReceive('getName')->andReturn('property');
-        $property->shouldReceive('getKind')->andReturn(ResourcePropertyKind::RESOURCE_REFERENCE);
-
-        $base = m::mock(ResourceEntityType::class);
-        $base->shouldReceive('isAbstract')->andReturn(false);
-        $base->shouldReceive('resolveProperty')->andReturn($property);
-        $base->shouldReceive('isAssignableFrom')->andReturn(true);
-        $concrete = m::mock(ResourceEntityType::class);
-        $concrete->shouldReceive('isAbstract')->andReturn(false);
-
-        $set = m::mock(ResourceSet::class);
-        $set->shouldReceive('getResourceType')->andReturn($base);
-
-        $expected = 'Base type must be abstract if concrete type supplied';
-        $actual = null;
-
-        try {
-            $foo = new ResourceAssociationSetEnd($set, $base, $property, $concrete);
-        } catch (\Exception $e) {
-            $actual = $e->getMessage();
-        }
-        $this->assertEquals($expected, $actual);
-    }
-
-    public function testResourceAssociationSetEndWithConcreteTypeNotDerivedFromBase()
-    {
-        $property = m::mock(ResourceProperty::class);
-        $property->shouldReceive('getName')->andReturn('property');
-        $property->shouldReceive('getKind')->andReturn(ResourcePropertyKind::RESOURCE_REFERENCE);
-
-        $base = m::mock(ResourceEntityType::class);
-        $base->shouldReceive('isAbstract')->andReturn(true);
-        $base->shouldReceive('resolveProperty')->andReturn($property);
-        $base->shouldReceive('isAssignableFrom')->andReturn(true);
-        $concrete = m::mock(ResourceEntityType::class);
-        $concrete->shouldReceive('isAbstract')->andReturn(false);
-        $concrete->shouldReceive('getBaseType')->andReturn(null);
-
-        $set = m::mock(ResourceSet::class);
-        $set->shouldReceive('getResourceType')->andReturn($base);
-
-        $expected = 'Concrete type must be a derived type of supplied base type';
-        $actual = null;
-
-        try {
-            $foo = new ResourceAssociationSetEnd($set, $base, $property, $concrete);
-        } catch (\Exception $e) {
-            $actual = $e->getMessage();
-        }
-        $this->assertEquals($expected, $actual);
-    }
-
     public function testGetConcreteTypeWhenNotExplicitlySupplied()
     {
         $property = m::mock(ResourceProperty::class);

--- a/tests/UnitTests/POData/Providers/Metadata/ResourceAssociationSetEndTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/ResourceAssociationSetEndTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use POData\Providers\Metadata\ResourceAssociationSetEnd;
 use POData\Providers\Metadata\ResourceEntityType;
 use POData\Providers\Metadata\ResourceProperty;
+use POData\Providers\Metadata\ResourcePropertyKind;
 use POData\Providers\Metadata\ResourceSet;
 use POData\Providers\Metadata\ResourceType;
 use UnitTests\POData\TestCase;
@@ -41,7 +42,7 @@ class ResourceAssociationSetEndTest extends TestCase
         $set = m::mock(ResourceSet::class);
         $type = m::mock(ResourceEntityType::class);
 
-        $property = new \StdClass();
+        $property = new \stdClass();
 
         // Type-hint mismatch error message is slightly different in PHP 7.1
         $expected = 'Argument 3 passed to POData\\Providers\\Metadata\\ResourceAssociationSetEnd::__construct() must be'
@@ -65,5 +66,109 @@ class ResourceAssociationSetEndTest extends TestCase
         $targ = version_compare(phpversion(), '7.1', '>=') ? $expected71 : $expected;
 
         $this->assertStringStartsWith($targ, $actual);
+    }
+
+    public function testResourceAssociationSetEndWithAbstractConcreteType()
+    {
+        $property = m::mock(ResourceProperty::class);
+        $property->shouldReceive('getName')->andReturn('property');
+        $property->shouldReceive('getKind')->andReturn(ResourcePropertyKind::RESOURCE_REFERENCE);
+
+        $base = m::mock(ResourceEntityType::class);
+        $base->shouldReceive('isAbstract')->andReturn(true);
+        $base->shouldReceive('resolveProperty')->andReturn($property);
+        $base->shouldReceive('isAssignableFrom')->andReturn(true);
+        $concrete = m::mock(ResourceEntityType::class);
+        $concrete->shouldReceive('isAbstract')->andReturn(true);
+
+        $set = m::mock(ResourceSet::class);
+        $set->shouldReceive('getResourceType')->andReturn($base);
+
+        $expected = 'Concrete type must not be abstract if explicitly supplied';
+        $actual = null;
+
+        try {
+            $foo = new ResourceAssociationSetEnd($set, $base, $property, $concrete);
+        } catch (\Exception $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testResourceAssociationSetEndWithConcreteBaseTypeAndConcreteType()
+    {
+        $property = m::mock(ResourceProperty::class);
+        $property->shouldReceive('getName')->andReturn('property');
+        $property->shouldReceive('getKind')->andReturn(ResourcePropertyKind::RESOURCE_REFERENCE);
+
+        $base = m::mock(ResourceEntityType::class);
+        $base->shouldReceive('isAbstract')->andReturn(false);
+        $base->shouldReceive('resolveProperty')->andReturn($property);
+        $base->shouldReceive('isAssignableFrom')->andReturn(true);
+        $concrete = m::mock(ResourceEntityType::class);
+        $concrete->shouldReceive('isAbstract')->andReturn(false);
+
+        $set = m::mock(ResourceSet::class);
+        $set->shouldReceive('getResourceType')->andReturn($base);
+
+        $expected = 'Base type must be abstract if concrete type supplied';
+        $actual = null;
+
+        try {
+            $foo = new ResourceAssociationSetEnd($set, $base, $property, $concrete);
+        } catch (\Exception $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testResourceAssociationSetEndWithConcreteTypeNotDerivedFromBase()
+    {
+        $property = m::mock(ResourceProperty::class);
+        $property->shouldReceive('getName')->andReturn('property');
+        $property->shouldReceive('getKind')->andReturn(ResourcePropertyKind::RESOURCE_REFERENCE);
+
+        $base = m::mock(ResourceEntityType::class);
+        $base->shouldReceive('isAbstract')->andReturn(true);
+        $base->shouldReceive('resolveProperty')->andReturn($property);
+        $base->shouldReceive('isAssignableFrom')->andReturn(true);
+        $concrete = m::mock(ResourceEntityType::class);
+        $concrete->shouldReceive('isAbstract')->andReturn(false);
+        $concrete->shouldReceive('getBaseType')->andReturn(null);
+
+        $set = m::mock(ResourceSet::class);
+        $set->shouldReceive('getResourceType')->andReturn($base);
+
+        $expected = 'Concrete type must be a derived type of supplied base type';
+        $actual = null;
+
+        try {
+            $foo = new ResourceAssociationSetEnd($set, $base, $property, $concrete);
+        } catch (\Exception $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetConcreteTypeWhenNotExplicitlySupplied()
+    {
+        $property = m::mock(ResourceProperty::class);
+        $property->shouldReceive('getName')->andReturn('property');
+        $property->shouldReceive('getKind')->andReturn(ResourcePropertyKind::RESOURCE_REFERENCE);
+        $expected = 'TypeWithNoName';
+
+        $base = m::mock(ResourceEntityType::class);
+        $base->shouldReceive('isAbstract')->andReturn(false);
+        $base->shouldReceive('resolveProperty')->andReturn($property);
+        $base->shouldReceive('isAssignableFrom')->andReturn(true);
+        $base->shouldReceive('getName')->andReturn($expected);
+
+        $set = m::mock(ResourceSet::class);
+        $set->shouldReceive('getResourceType')->andReturn($base);
+
+        $foo = new ResourceAssociationSetEnd($set, $base, $property);
+        $result = $foo->getConcreteType();
+        $actual = $result->getName();
+        $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
Modify relation hookup slightly to allow for clients to supply a specific type for a relation association set endpoint where desired.  Here, I've used it to enable a specific derived entity type to take over for its abstract parent.