### PR TITLE
Add brute-force sanity check to addResourceReferenceInternal

### DIFF
--- a/src/POData/Providers/Metadata/SimpleMetadataProvider.php
+++ b/src/POData/Providers/Metadata/SimpleMetadataProvider.php
@@ -682,6 +682,9 @@ class SimpleMetadataProvider implements IMetadataProvider
         );
         $mult = $resourceMult;
         $backMult = $many ? '*' : $backMultArray[$resourceMult];
+        if (false === $many && '*' == $backMult && '*' == $resourceMult) {
+            $backMult = '1';
+        }
         $this->getMetadataManager()->addNavigationPropertyToEntityType(
             $this->oDataEntityMap[$sourceResourceType->getFullName()],
             $mult,
@@ -818,15 +821,16 @@ class SimpleMetadataProvider implements IMetadataProvider
     public function addResourceSetReferenceProperty(
         ResourceEntityType $resourceType,
         $name,
-        $targetResourceSet,
-        ResourceEntityType $concreteType = null
+        ResourceSet $targetResourceSet,
+        ResourceEntityType $concreteType = null,
+        $single = false
     ) {
         $this->addReferencePropertyInternal(
             $resourceType,
             $name,
             $targetResourceSet,
             '*',
-            null,
+            (true === $single) ? false : null,
             $concreteType
         );
     }

--- a/tests/UnitTests/POData/Providers/Metadata/SimpleMetadataProviderTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/SimpleMetadataProviderTest.php
@@ -765,6 +765,37 @@ class SimpleMetadataProviderTest extends TestCase
         $this->assertEquals([$aft], $foo->getDerivedTypes($fore));
     }
 
+    public function testAddResourceSetReferenceWithOtherEndSingle()
+    {
+        $forward = new reusableEntityClass4('foo', 'bar');
+        $back = new reusableEntityClass5('foo', 'bar');
+
+        $foo = new SimpleMetadataProvider('string', 'String');
+
+        $fore = $foo->addEntityType(new \ReflectionClass(get_class($forward)), 'fore');
+        $aft = $foo->addEntityType(new \ReflectionClass(get_class($back)), 'aft');
+        $this->assertTrue($fore instanceof ResourceType);
+        $this->assertTrue($aft instanceof ResourceType);
+
+        $foreSet = $foo->addResourceSet('foreSet', $fore);
+        $aftSet = $foo->addResourceSet('aftSet', $aft);
+        $this->assertTrue($foreSet instanceof ResourceSet);
+        $this->assertTrue($aftSet instanceof ResourceSet);
+
+        $foo->addResourceSetReferenceProperty($fore, 'fore_aft', $aftSet, null, true);
+        $xml = $foo->getXML();
+        $assocName = '<Association Name="fore_fore_aft_aft">';
+        $fwdEnd = '<End Type="String.fore" Role="fores_fore_aft" Multiplicity="*"/>';
+        $revEnd = '<End Type="String.aft" Role="afts" Multiplicity="1"/>';
+        $navProp = '<NavigationProperty Name="fore_aft" Relationship="String.fore_fore_aft_aft" ToRole="afts" '
+                   .'FromRole="fores_fore_aft" cg:GetterAccess="Public" cg:SetterAccess="Public"/>';
+
+        $this->assertTrue(false !== strpos($xml, $assocName));
+        $this->assertTrue(false !== strpos($xml, $fwdEnd));
+        $this->assertTrue(false !== strpos($xml, $revEnd));
+        $this->assertTrue(false !== strpos($xml, $navProp));
+    }
+
     public function testGetXML()
     {
         $cereal = m::mock(Serializer::class);


### PR DESCRIPTION
If we're hooking up a resource set (via addResourceSetReferenceProperty) and have specified the other end as a singleton, then make it so just before things get hooked up.