### PR TITLE
Handle null payloads more effectively

### DIFF
--- a/src/POData/Providers/Metadata/ResourceType.php
+++ b/src/POData/Providers/Metadata/ResourceType.php
@@ -836,7 +836,7 @@ abstract class ResourceType
      */
     public function setPropertyValue($entity, $property, $value)
     {
-        $targ = ($entity instanceof QueryResult) ? $entity->results[0] : $entity;
+        $targ = $this->unpackEntityForPropertyGetSet($entity);
         ReflectionHandler::setProperty($targ, $property, $value);
 
         return $this;
@@ -849,7 +849,7 @@ abstract class ResourceType
      */
     public function getPropertyValue($entity, $property)
     {
-        $targ = ($entity instanceof QueryResult) ? $entity->results[0] : $entity;
+        $targ = $this->unpackEntityForPropertyGetSet($entity);
         return ReflectionHandler::getProperty($targ, $property);
     }
 
@@ -877,5 +877,17 @@ abstract class ResourceType
             $this->type instanceof \ReflectionClass || $this->type instanceof IType,
             '_type neither instance of reflection class nor IType'
         );
+    }
+
+    /**
+     * @param $entity
+     * @return mixed|null
+     */
+    private function unpackEntityForPropertyGetSet($entity)
+    {
+        $targ = ($entity instanceof QueryResult)
+            ? (is_array($entity->results) && 0 < count($entity->results)) ? $entity->results[0] : null
+            : $entity;
+        return $targ;
     }
 }

--- a/src/POData/UriProcessor/RequestExpander.php
+++ b/src/POData/UriProcessor/RequestExpander.php
@@ -9,6 +9,7 @@ use POData\Providers\Metadata\ResourcePropertyKind;
 use POData\Providers\Metadata\ResourceSetWrapper;
 use POData\Providers\Metadata\ResourceTypeKind;
 use POData\Providers\ProvidersWrapper;
+use POData\Providers\Query\QueryResult;
 use POData\Providers\Query\QueryType;
 use POData\UriProcessor\QueryProcessor\ExpandProjectionParser\ExpandedProjectionNode;
 
@@ -129,6 +130,9 @@ class RequestExpander
 
             foreach ($result as $entry) {
                 // Check for null entry
+                if ($entry instanceof QueryResult && empty($entry->results)) {
+                    continue;
+                }
                 if ($isCollection) {
                     $result1 = $this->executeCollectionExpansionGetRelated($expandedProjectionNode, $entry);
                     if (!empty($result1)) {

--- a/tests/UnitTests/POData/Providers/Metadata/ResourceTypeTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/ResourceTypeTest.php
@@ -17,7 +17,9 @@ use POData\Providers\Metadata\ResourceType;
 use POData\Providers\Metadata\ResourceTypeKind;
 use POData\Providers\Metadata\Type\EdmPrimitiveType;
 use POData\Providers\Metadata\Type\IType;
+use POData\Providers\Query\QueryResult;
 use ReflectionClass;
+use UnitTests\POData\Facets\NorthWind4\NorthWindMetadata;
 use UnitTests\POData\ObjectModel\reusableEntityClass2;
 use UnitTests\POData\TestCase;
 
@@ -238,5 +240,85 @@ class ResourceTypeTest extends TestCase
     {
         $foo = ResourceType::getPrimitiveResourceType(EdmPrimitiveType::INT64);
         $this->assertEquals('Int64', $foo->getName());
+    }
+
+    public function testSetValueWithEmptyQueryResult()
+    {
+        $meta = NorthWindMetadata::create();
+        $type = $meta->resolveResourceType('Customer');
+
+        $entity = new QueryResult();
+        $entity->results = [];
+        $propName = 'CompanyName';
+        $value = 'Company';
+
+        $expected = 'The parameter class is expected to be either a string or an object';
+        $actual = null;
+
+        try {
+            $type->setPropertyValue($entity, $propName, $value);
+        } catch (\ReflectionException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testSetValueWithNull()
+    {
+        $meta = NorthWindMetadata::create();
+        $type = $meta->resolveResourceType('Customer');
+
+        $entity = null;
+        $propName = 'CompanyName';
+        $value = 'Company';
+
+        $expected = 'The parameter class is expected to be either a string or an object';
+        $actual = null;
+
+        try {
+            $type->setPropertyValue($entity, $propName, $value);
+        } catch (\ReflectionException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetValueWithEmptyQueryResult()
+    {
+        $meta = NorthWindMetadata::create();
+        $type = $meta->resolveResourceType('Customer');
+
+        $entity = new QueryResult();
+        $entity->results = [];
+        $propName = 'CompanyName';
+
+        $expected = 'Property POData\Common\ReflectionHandler::$CompanyName does not exist';
+        $actual = null;
+
+        try {
+            $type->getPropertyValue($entity, $propName);
+        } catch (\ReflectionException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetValueWithNull()
+    {
+        $meta = NorthWindMetadata::create();
+        $type = $meta->resolveResourceType('Customer');
+
+        $entity = null;
+        $propName = 'CompanyName';
+
+        $expected = 'Property POData\Common\ReflectionHandler::$CompanyName does not exist';
+        $actual = null;
+
+        try {
+            $type->getPropertyValue($entity, $propName);
+        } catch (\ReflectionException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
We weren't handling QueryResult objects with empty results arrays - were instead blithely assuming those arrays weren't empty.  This pull req fixes that and explicitly handles empty-array case.