### PR TITLE
Add forward and reverse forward-slash mapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 
 
 before_script:
+  - ssh-keygen -t rsa -b 4096 -C "travis@example.com" -f ~/.ssh/id_rsa -P ""
   - composer global require hirak/prestissimo
   - composer install
 #  - wget http://getcomposer.org/composer.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+   * Handle forward slashes in underlying data.  (see [#171] (https://github.com/Algo-Web/POData/pull/171))
    * Extend KeyDescriptor to return key values as ODataProperty array.  (see [#165] (https://github.com/Algo-Web/POData/pull/165))
 
 0.2.0 (2017-03-02)

--- a/src/POData/Providers/Metadata/Type/EdmString.php
+++ b/src/POData/Providers/Metadata/Type/EdmString.php
@@ -77,6 +77,7 @@ class EdmString implements IType
      */
     public function convert($stringValue)
     {
+        $stringValue = str_replace('%C3%82%C2%BB', '/', $stringValue);
         //Consider the odata url option
         //$filter=ShipName eq 'Antonio%20Moreno%20Taquer%C3%ADa'
         //WebOperationContext will do urldecode, so the clause become
@@ -105,6 +106,7 @@ class EdmString implements IType
      */
     public function convertToOData($value)
     {
+        $value = str_replace('/', '»', $value);
         return '\'' . str_replace('%27', "''", urlencode(utf8_encode($value))) . '\'';
     }
 

--- a/src/POData/Providers/Metadata/Type/EdmString.php
+++ b/src/POData/Providers/Metadata/Type/EdmString.php
@@ -77,7 +77,7 @@ class EdmString implements IType
      */
     public function convert($stringValue)
     {
-        $stringValue = str_replace('%C3%82%C2%BB', '/', $stringValue);
+        $value = str_replace('%C3%82%C2%BB', '/', $stringValue);
         //Consider the odata url option
         //$filter=ShipName eq 'Antonio%20Moreno%20Taquer%C3%ADa'
         //WebOperationContext will do urldecode, so the clause become
@@ -87,12 +87,12 @@ class EdmString implements IType
         //this function is used to remove the pre-post quotes from Token::Text
         //i.e. 'Antonio Moreno Taquería'
         //to Antonio Moreno Taquería
-        $len = strlen($stringValue);
+        $len = strlen($value);
         if (2 > $len) {
-            return $stringValue;
+            return $value;
         }
 
-        return substr($stringValue, 1, $len - 2);
+        return substr($value, 1, $len - 2);
     }
 
     /**
@@ -106,8 +106,8 @@ class EdmString implements IType
      */
     public function convertToOData($value)
     {
-        $value = str_replace('/', '»', $value);
-        return '\'' . str_replace('%27', "''", urlencode(utf8_encode($value))) . '\'';
+        $rawValue = str_replace('/', '»', $value);
+        return '\'' . str_replace('%27', "''", urlencode(utf8_encode($rawValue))) . '\'';
     }
 
     /**

--- a/src/POData/UriProcessor/ResourcePathProcessor/SegmentParser/SegmentParser.php
+++ b/src/POData/UriProcessor/ResourcePathProcessor/SegmentParser/SegmentParser.php
@@ -103,6 +103,7 @@ class SegmentParser
         $identifier = substr($segment, 0, $predicateStart);
         ++$predicateStart;
         $keyPredicate = substr($segment, $predicateStart, $segmentLength - $predicateStart - 1);
+        $keyPredicate = str_replace('%C3%82%C2%BB', '/', $keyPredicate);
     }
 
     /**

--- a/tests/UnitTests/POData/Providers/Metadata/Type/StringTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/StringTest.php
@@ -159,4 +159,15 @@ class StringTest extends TestCase
      *  Begin Type Specific Tests
      *
      */
+
+    public function testRoundTripWithSlashes()
+    {
+        $type = $this->getAsIType();
+        $value = 'OMG/LOL/WTF/BBQ';
+
+        $convert = $type->convertToOData($value);
+        $final = urldecode($type->convert($convert));
+        // assert conversion round-trips
+        $this->assertEquals($value, urldecode($final));
+    }
 }


### PR DESCRIPTION
Putting forward slashes in key fields causes all sorts of problems
with queries as forward slashes are a reserved token in urls.  This commit
maps outbound forward slashes (such as those en-route to a nav link) to »
and vice versa.

This should resolve #170 