### PR TITLE
Loosen Carbon constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "myclabs/php-enum": "1.2.0",
         "php": ">=5.6.4",
         "illuminate/http": ">=5.1",
-        "nesbot/carbon": ">2.0",
+        "nesbot/carbon": "^1.0|^2.0",
         "algo-web/o-data-metadata": "0.1.*|dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
Previous code broke at least POData-Laravel, which still supports Laravel versions with Carbon ^1.0 deps, so I've pulled back the version constraint to fit.