### PR TITLE
Characterise empty needles

### DIFF
--- a/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
+++ b/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
@@ -263,6 +263,16 @@ class PHPExpressionProviderTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testonFunctionCallExpressionEndsWithEmptyNeedle()
+    {
+        $desc = FunctionDescription::filterFunctionDescriptions()["endswith"][0];
+        $prov = new PHPExpressionProvider('foo');
+
+        $issue = $prov->onFunctionCallExpression($desc, ['\'Property\'', '\'\'']);
+
+        eval($issue . ';');
+    }
+
     public function testonPropertyAccessExpression()
     {
         $property = m::mock(PropertyAccessExpression::class)->makePartial();

--- a/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
+++ b/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
@@ -273,6 +273,24 @@ class PHPExpressionProviderTest extends TestCase
         eval($issue . ';');
     }
 
+    public function testonFunctionCallExpressionIndexOfEmptyNeedle()
+    {
+        $desc = FunctionDescription::filterFunctionDescriptions()["indexof"][0];
+        $prov = new PHPExpressionProvider('foo');
+
+        $issue = $prov->onFunctionCallExpression($desc, ['\'Property\'', '\'\'']);
+
+        $expected = 'strpos(): Empty needle';
+        $actual = null;
+
+        try {
+            eval($issue . ';');
+        } catch (\Exception $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testonPropertyAccessExpression()
     {
         $property = m::mock(PropertyAccessExpression::class)->makePartial();

--- a/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
+++ b/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
@@ -291,6 +291,24 @@ class PHPExpressionProviderTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testonFunctionCallExpressionSubstringOfEmptyNeedle()
+    {
+        $desc = FunctionDescription::filterFunctionDescriptions()["substringof"][0];
+        $prov = new PHPExpressionProvider('foo');
+
+        $issue = $prov->onFunctionCallExpression($desc, ['\'\'', '\'Property\'']);
+
+        $expected = 'strpos(): Empty needle';
+        $actual = null;
+
+        try {
+            eval($issue . ';');
+        } catch (\Exception $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testonPropertyAccessExpression()
     {
         $property = m::mock(PropertyAccessExpression::class)->makePartial();

--- a/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
+++ b/tests/UnitTests/POData/Providers/Expression/PHPExpressionProviderTest.php
@@ -245,6 +245,24 @@ class PHPExpressionProviderTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testonFunctionCallExpressionStartsWithEmptyNeedle()
+    {
+        $desc = FunctionDescription::filterFunctionDescriptions()["startswith"][0];
+        $prov = new PHPExpressionProvider('foo');
+
+        $issue = $prov->onFunctionCallExpression($desc, ['\'Property\'', '\'\'']);
+
+        $expected = 'strpos(): Empty needle';
+        $actual = null;
+
+        try {
+            eval($issue . ';');
+        } catch (\Exception $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testonPropertyAccessExpression()
     {
         $property = m::mock(PropertyAccessExpression::class)->makePartial();


### PR DESCRIPTION
Characterises existing function expression handling when passed empty needles.  Answers #180 .