### PR TITLE
make pretty print on by default

### DIFF
--- a/src/POData/Configuration/ServiceConfiguration.php
+++ b/src/POData/Configuration/ServiceConfiguration.php
@@ -128,9 +128,7 @@ class ServiceConfiguration implements IServiceConfiguration
         $this->maxVersion = ProtocolVersion::V3(); //We default to the highest version
 
         $this->validateETagHeader = true;
-        // basically display errors has a development value of on and a production value of off. so if not specified
-        // use that
-        $this->setPrettyOutput(in_array(strtolower(ini_get('display_errors')), array('1', 'on', 'true')));
+        $this->setPrettyOutput(true);
         $this->setLineEndings(PHP_EOL);
     }
 


### PR DESCRIPTION
And only one small commend towards that. I saw you made the default value for the pretty print to be dependent on php error_reporting settings somewhere.
I would discourage from doing that because often dev/test server may have that setting different from productive env. So, it makes the pre-production testing less reliable. It may also be not transparent for those who will be debugging the output and will start wondering, why json looks differently.
I would just put it to pretty by default.

_Originally posted by @kirill533 in https://github.com/Algo-Web/POData/issues/240#issuecomment-626168004_